### PR TITLE
Allows use type of cellView directly

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0D8513D34612125E9ADC6A29E2ACD9B0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
 		17A50D07A017A44F937051301320BD69 /* Pods-JTAppleCalendar_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AF014C9CECE6B439B1F4484B44F6839D /* Pods-JTAppleCalendar_Tests-dummy.m */; };
+		22BFB12C1D114ADF00579170 /* JTAppleCalendarCellViewSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BFB12B1D114ADF00579170 /* JTAppleCalendarCellViewSource.swift */; };
 		3A17D016A98E131F39D1631FCA308C3C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4E89230EF59BC255123B67864ACF77 /* Foundation.framework */; };
 		50912F176483B1CCF6D09FBF6574CCC4 /* Pods-JTAppleCalendar_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CFEAC2F61AA0E311E2C41A521A947487 /* Pods-JTAppleCalendar_Example-dummy.m */; };
 		54EF02B44C818A0BB12D32BC5F644766 /* JTAppleCalendar-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C82A8461BAC14D837D1C245ACCC05B36 /* JTAppleCalendar-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -56,6 +57,7 @@
 		0677EC1ACF7D28075CE61A36E7053D39 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1C379A8DA30C0BA959E8301AEC8DEAFF /* Pods-JTAppleCalendar_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-JTAppleCalendar_Example-umbrella.h"; sourceTree = "<group>"; };
 		21E678B9D88C5357159E7F8519FEEC3D /* Pods-JTAppleCalendar_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-JTAppleCalendar_Tests.release.xcconfig"; sourceTree = "<group>"; };
+		22BFB12B1D114ADF00579170 /* JTAppleCalendarCellViewSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JTAppleCalendarCellViewSource.swift; sourceTree = "<group>"; };
 		2AE1DF0CF022267650A83BDF39298C12 /* Pods-JTAppleCalendar_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-JTAppleCalendar_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		2C34373990FC16119C2D1059659AA605 /* Pods-JTAppleCalendar_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-JTAppleCalendar_Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		35A62886FA6572337D6AE300FD8EED57 /* JTAppleCalendar.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = JTAppleCalendar.modulemap; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 		B621D6FA7D7B42029C14E8F76BD84A8C /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				22BFB12B1D114ADF00579170 /* JTAppleCalendarCellViewSource.swift */,
 				6B2601151C99F7F2003ED015 /* JTAppleCalendarView.swift */,
 				6BDFF7CB1C9DD34500571F98 /* JTAppleDayCell.swift */,
 				6B2601171C99F7F2003ED015 /* JTAppleViews.swift */,
@@ -443,6 +446,7 @@
 				6B26011C1C99F7F2003ED015 /* JTAppleCalendarLayout.swift in Sources */,
 				6B8B06FA1D0773AC00CE0D55 /* JTCalendarProtocols.swift in Sources */,
 				6B26011B1C99F7F2003ED015 /* JTAppleViews.swift in Sources */,
+				22BFB12C1D114ADF00579170 /* JTAppleCalendarCellViewSource.swift in Sources */,
 				6B2601191C99F7F2003ED015 /* JTAppleCalendarView.swift in Sources */,
 				D8F6CFC26E5DD4CDEE4AFDA7DEA0E4D5 /* JTAppleCalendar-dummy.m in Sources */,
 				6BDFF7CC1C9DD34500571F98 /* JTAppleDayCell.swift in Sources */,

--- a/Sources/Classes/JTAppleCalendarCellViewSource.swift
+++ b/Sources/Classes/JTAppleCalendarCellViewSource.swift
@@ -1,0 +1,13 @@
+//
+//  JTAppleCalendarCellViewSource.swift
+//  Pods
+//
+//  Created by Matous Michalik <i@matousmichalik.com> on 15/06/16.
+//
+//
+
+enum JTAppleCallendarCellViewSource {
+	case fromXib(String)
+	case fromType(AnyClass)
+	case fromClassName(String)
+}

--- a/Sources/Classes/JTAppleCalendarView.swift
+++ b/Sources/Classes/JTAppleCalendarView.swift
@@ -630,13 +630,22 @@ public class JTAppleCalendarView: UIView {
     }
     
     func xibFileValid() -> Bool {
-        //"Did you remember to register your xib file to JTAppleCalendarView? call the registerCellViewXib method on it because xib filename is nil"
-        guard let xibName =  cellViewFromDeveloper else { return false }
-        //"your nib file name \(cellViewXibName) could not be loaded)"
-        guard let viewObject = NSBundle.mainBundle().loadNibNamed(xibName, owner: self, options: [:]) where viewObject.count > 0 else { return false }
-        //"xib file class does not conform to the protocol<JTAppleDayCellViewProtocol>"
-        guard let _ = viewObject[0] as? JTAppleDayCellView else { return false }
-        return true
+        // Did you remember to register your JTAppleCalendarView? Because we can't find any"
+        guard let cellViewSource = cellViewSource else { return false }
+        
+        switch cellViewSource {
+        case let .fromXib(xibName):
+            // "your nib file name \(cellViewXibName) could not be loaded)"
+            guard let viewObject = NSBundle.mainBundle().loadNibNamed(xibName, owner: self, options: [:]) where viewObject.count > 0 else { return false }
+            // "xib file class does not conform to the protocol<JTAppleDayCellViewProtocol>"
+            guard let _ = viewObject[0] as? JTAppleDayCellView else { return false }
+            
+            return true
+        default:
+            // todo: check other source cases
+            // asume that developer used right type of class
+            return true
+        }
     }
     
     func generateNewLayout() -> UICollectionViewLayout {

--- a/Sources/Classes/JTAppleDayCell.swift
+++ b/Sources/Classes/JTAppleDayCell.swift
@@ -6,63 +6,75 @@
 //  Copyright © 2016 OS-Tech. All rights reserved.
 //
 
-var cellViewFromDeveloper: String?
-var cellViewIsClass: Bool?
+var cellViewSource: JTAppleCallendarCellViewSource?
 
 var internalCellInset: CGPoint = CGPoint(x: 3.0, y: 3.0)
 
 /// The JTAppleDayCell class defines the attributes and behavior of the cells that appear in JTAppleCalendarView objects.
 public class JTAppleDayCell: UICollectionViewCell {
-    
-    var cellView: JTAppleDayCellView!
 
-    func setupCellView() {
-        
-        guard let validCell = cellViewFromDeveloper else {
-            print("Did you remember to register your xib file to JTAppleCalendarView? call the registerCellViewXib method on it because xib filename is nil")
-            return
-        }
-        
-        var theView: JTAppleDayCellView
-        
-        if !(cellViewIsClass!) {
-            let viewObject = NSBundle.mainBundle().loadNibNamed(validCell, owner: self, options: [:])
-            assert(viewObject.count > 0, "your nib file name \(validCell) could not be loaded)")
-            
-            guard let view = viewObject[0] as? JTAppleDayCellView else {
-                print("xib file class does not conform to the protocol<JTAppleDayCellViewProtocol>")
-                assert(false )
-                return
-            }
-            theView = view
-        } else {
-            guard let theCellClass = NSBundle.mainBundle().classNamed(validCell) as? JTAppleDayCellView.Type else {
-                print("Error loading registered class: '\(validCell)'")
-                print("Make sure that: \n\n(1) It is a subclass of: 'JTAppleDayCellView' \n(2) You registered your class using the fully qualified name like so -->  'theNameOfYourProject.theNameOfYourClass'\n")
-                assert(false)
-                return
-            }
-            theView = theCellClass.init()
-        }
-    
-        updateCellView(theView)
-    }
-    
-    func updateCellView(view: JTAppleDayCellView) {
-        let vFrame = CGRectInset(self.frame, internalCellInset.x, internalCellInset.y)
-        view.frame = vFrame
-        view.center = CGPoint(x: self.bounds.size.width * 0.5, y: self.bounds.size.height * 0.5)
-        cellView = view
-    }
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        self.setupCellView()
-        self.addSubview(cellView)
-    }
-    
-    /// Returns an object initialized from data in a given unarchiver.
-    required public init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
+	var cellView: JTAppleDayCellView!
+
+	func setupCellView() {
+
+		guard let cellSource = cellViewSource else {
+			print("Did you remember to register your JTAppleCalendarView? Because we can't find any")
+			return
+		}
+
+		var theView: JTAppleDayCellView
+
+		switch cellSource {
+		case let .fromXib(xibName):
+			let viewObject = NSBundle.mainBundle().loadNibNamed(xibName, owner: self, options: [:])
+			assert(viewObject.count > 0, "your nib file name \(xibName) could not be loaded)")
+
+			guard let view = viewObject[0] as? JTAppleDayCellView else {
+				print("xib file class does not conform to the protocol<JTAppleDayCellViewProtocol>")
+				assert(false)
+				return
+			}
+			theView = view
+			break
+		case let .fromClassName(cellClassName):
+			guard let theCellClass = NSBundle.mainBundle().classNamed(cellClassName) as? JTAppleDayCellView.Type else {
+				print("Error loading registered class: '\(cellClassName)'")
+				print("Make sure that: \n\n(1) It is a subclass of: 'JTAppleDayCellView' \n(2) You registered your class using the fully qualified name like so -->  'theNameOfYourProject.theNameOfYourClass'\n")
+				assert(false)
+				return
+			}
+			theView = theCellClass.init()
+			break
+
+		case let .fromType(cellType):
+			guard let theCellClass = cellType as? JTAppleDayCellView.Type else {
+				print("Error loading registered class: '\(cellType)'")
+				print("Make sure that: \n\n(1) It is a subclass of: 'JTAppleDayCellView'\n")
+				assert(false)
+				return
+			}
+			theView = theCellClass.init()
+			break
+		}
+
+		updateCellView(theView)
+	}
+
+	func updateCellView(view: JTAppleDayCellView) {
+		let vFrame = CGRectInset(self.frame, internalCellInset.x, internalCellInset.y)
+		view.frame = vFrame
+		view.center = CGPoint(x: self.bounds.size.width * 0.5, y: self.bounds.size.height * 0.5)
+		cellView = view
+	}
+
+	override init(frame: CGRect) {
+		super.init(frame: frame)
+		self.setupCellView()
+		self.addSubview(cellView)
+	}
+
+	/// Returns an object initialized from data in a given unarchiver.
+	required public init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+	}
 }

--- a/Sources/Classes/UserInteractionFunctions.swift
+++ b/Sources/Classes/UserInteractionFunctions.swift
@@ -56,15 +56,19 @@ extension JTAppleCalendarView {
     /// Let's the calendar know which cell xib to use for the displaying of it's date-cells.
     /// - Parameter name: The name of the xib of your cell design
     public func registerCellViewXib(fileName name: String) {
-        cellViewIsClass = false
-        cellViewFromDeveloper = name
+        cellViewSource = JTAppleCallendarCellViewSource.fromXib(name)
     }
     
     /// Let's the calendar know which cell class to use for the displaying of it's date-cells.
-    /// - Parameter name: The name of the xib of your cell design
+    /// - Parameter name: The class name of your cell design
     public func registerCellViewClass(fileName name: String) {
-        cellViewIsClass = true
-        cellViewFromDeveloper = name
+        cellViewSource = JTAppleCallendarCellViewSource.fromClassName(name)
+    }
+    
+    /// Let's the calendar know which cell class to use for the displaying of it's date-cells.
+    /// - Parameter name: The type of your cell design
+    public func registerCellViewClass(cellClass cellClass: AnyClass) {
+        cellViewSource = JTAppleCallendarCellViewSource.fromType(cellClass)
     }
     
     


### PR DESCRIPTION
Uses enum JTAppleCalendarViewSource as definition of class or Xib for JTAppleDayCell subview.

As bonus allows register class for DayCell directly with type instead of string
```
calendar.registerCellViewClass(cellClass: CellView.self)
```

---

@patchthecode please take a look, and tell me what are you thinking.

I think this simplifies JTAppleDayCell#setupCellView code. But i really just want to register cells with it's type instead of xib or string name of class.


PS: I sucks on naming things so please rename anything to your liking.