### PR TITLE
Deprecating numberOfRowsPerMonth instead of removing it so it will generate a build warning instead of a failure fro those who were using it.

### DIFF
--- a/Sources/Classes/JTAppleCalendarView.swift
+++ b/Sources/Classes/JTAppleCalendarView.swift
@@ -187,6 +187,10 @@ public class JTAppleCalendarView: UIView {
     // Keeps track of item size for a section. This is an optimization
     var scrollInProgress = false
     private var layoutNeedsUpdating = false
+    
+    @available(*, deprecated, message="This has been deprecated in 4.0.3. Please consider removing it from your code")
+    public var numberOfRowsPerMonth: Int = 0
+    
     /// The object that acts as the data source of the calendar view.
     public var dataSource : JTAppleCalendarViewDataSource? {
         didSet {


### PR DESCRIPTION
It is better to deprecate the value rather than removing it especially on a minor uptake 4.0.2 to 4.0.3 as it will break the build on code using that value.