### PR TITLE
Updated .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ script:
   - set -o pipefail
   - xcodebuild -version
   - xcodebuild -workspace Example/JTAppleCalendar.xcworkspace -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"
-  -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c
+    -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: objective-c
 osx_image: xcode7.3
 env:
-- DESTINATION="OS=9.3,name=iPhone 6s" SCHEME="JTAppleCalendar-Example" SDK=iphonesimulator9.3 CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO
+  - DESTINATION="OS=9.3,name=iPhone 6s" SCHEME="JTAppleCalendar-Example" SDK=iphonesimulator9.3
 before_install:
-- gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+  - cd Example
+  - pod install
 script:
-- set -o pipefail
-- xcodebuild -version
-- xcodebuild -workspace Example/JTAppleCalendar.xcworkspace -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"
--configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c
+  - set -o pipefail
+  - xcodebuild -version
+  - xcodebuild -workspace Example/JTAppleCalendar.xcworkspace -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"
+  -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c
 notifications:
-email: false
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
-language: swift
-xcode_workspace: Example/JTAppleCalendar.xcworkspace
-xcode_scheme: JTAppleCalendar-Example
-xcode_sdk: iphonesimulator
-env: CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO
+language: objective-c
+osx_image: xcode7.3
+env:
+- DESTINATION="OS=9.3,name=iPhone 6s" SCHEME="JTAppleCalendar-Example" SDK=iphonesimulator9.3 CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO
+before_install:
+- gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+script:
+- set -o pipefail
+- xcodebuild -version
+- xcodebuild -workspace Example/JTAppleCalendar.xcworkspace -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"
+-configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c
 notifications:
-  email: false
+email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 script:
   - set -o pipefail
   - xcodebuild -version
-  - xcodebuild -workspace Example/JTAppleCalendar.xcworkspace -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"
+  - xcodebuild -workspace JTAppleCalendar.xcworkspace -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION"
     -configuration Debug ONLY_ACTIVE_ARCH=NO test | xcpretty -c
 notifications:
   email: false

--- a/Example/JTAppleCalendar.xcodeproj/project.pbxproj
+++ b/Example/JTAppleCalendar.xcodeproj/project.pbxproj
@@ -607,6 +607,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -624,6 +625,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
- Updated travis.yml to use xcodebuild instead of xctool (Better compatibility with Swift. 

>  osx_image: xcode7.3
 env:
 - DESTINATION="OS=9.3,name=iPhone 6s" SCHEME="JTAppleCalendar-Example" SDK=iphonesimulator9.3


- Update XCode test to match the SDK of the Example
- Install pod on the fly when using travis CI

> before_install:
  - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
  - cd Example
  - pod install