### PR TITLE
ScrollToPrevious/NextSection functions now calls delegate

### DIFF
--- a/Sources/Classes/UserInteractionFunctions.swift
+++ b/Sources/Classes/UserInteractionFunctions.swift
@@ -225,7 +225,7 @@ extension JTAppleCalendarView {
     public func scrollToNextSegment(triggerScrollToDateDelegate: Bool = false, animateScroll: Bool = true, completionHandler:(()->Void)? = nil) {
         let page = currentSectionPage + 1
         if page < monthInfo.count {
-            scrollToSection(page,  animateScroll: animateScroll, completionHandler: completionHandler)
+            scrollToSection(page, triggerScrollToDateDelegate: triggerScrollToDateDelegate, animateScroll: animateScroll, completionHandler: completionHandler)
         }
     }
     /// Scrolls the calendar view to the previous section view. It will execute a completion handler at the end of scroll animation if provided.
@@ -234,7 +234,7 @@ extension JTAppleCalendarView {
     public func scrollToPreviousSegment(triggerScrollToDateDelegate: Bool = false, animateScroll: Bool = true, completionHandler:(()->Void)? = nil) {
         let page = currentSectionPage - 1
         if page > -1 {
-            scrollToSection(page, animateScroll: animateScroll, completionHandler: completionHandler)
+            scrollToSection(page, triggerScrollToDateDelegate: triggerScrollToDateDelegate, animateScroll: animateScroll, completionHandler: completionHandler)
         }
     }
 


### PR DESCRIPTION
`ScrollToPreviousSection` and `ScrollToNextSection` have a `triggerScrollToDateDelegate` parameter that is not interpreted in the implementation. This is a fix proposal for 4.1.3