### PR TITLE
- Fix Cocoapods 1.0+ depreciation

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,11 +1,11 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-target 'JTAppleCalendar_Example', :exclusive => true do
+target 'JTAppleCalendar_Example' do
   pod 'JTAppleCalendar', :path => '../'
 end
 
-target 'JTAppleCalendar_Tests', :exclusive => true do
+target 'JTAppleCalendar_Tests' do
   pod 'JTAppleCalendar', :path => '../'
 
   


### PR DESCRIPTION
Just remove some deprecated tag in the example Podfile.