### PR TITLE
Add Tailor and clear warnings

### DIFF
--- a/.tailor.yml
+++ b/.tailor.yml
@@ -1,0 +1,2 @@
+except:
+    - upper-camel-case

--- a/Example/JTAppleCalendar iOS Example/AnimationClass.swift
+++ b/Example/JTAppleCalendar iOS Example/AnimationClass.swift
@@ -8,21 +8,28 @@
 
 import UIKit
 class AnimationClass {
+
     class func BounceEffect() -> (UIView, @escaping (Bool) -> Void) -> () {
+
         return {
             view, completion in
             view.transform = CGAffineTransform(scaleX: 0.5, y: 0.5)
-            UIView.animate(withDuration: 0.5,
-                           delay: 0, usingSpringWithDamping: 0.3,
-                           initialSpringVelocity: 0.1,
-                           options: UIViewAnimationOptions.beginFromCurrentState,
-                           animations: {
-                                view.transform = CGAffineTransform(scaleX: 1, y: 1)
-                            },
-                           completion: completion)
+            UIView.animate(
+                withDuration: 0.5,
+                delay: 0, usingSpringWithDamping: 0.3,
+                initialSpringVelocity: 0.1,
+                options: UIViewAnimationOptions.beginFromCurrentState,
+                animations: {
+                    view.transform = CGAffineTransform(scaleX: 1, y: 1)
+                },
+                completion: completion
+            )
         }
+
     }
-    class func FadeOutEffect() -> (UIView, @escaping (Bool) -> Void) -> () {
+
+    class func fadeOutEffect() -> (UIView, @escaping (Bool) -> Void) -> () {
+
         return {
             view, completion in
             UIView.animate(withDuration: 0.6,
@@ -34,13 +41,18 @@ class AnimationClass {
                             },
                            completion: completion)
         }
+
     }
-    fileprivate class func get3DTransformation(_ angle: Double) -> CATransform3D {
+
+    fileprivate class func get3DTransformation(_ angle: Double) ->
+                                                            CATransform3D {
         var transform = CATransform3DIdentity
         transform.m34 = -1.0 / 500.0
-        transform = CATransform3DRotate(transform, CGFloat(angle * M_PI / 180.0), 0, 1, 0.0)
+        transform = CATransform3DRotate(transform,
+                                CGFloat(angle * M_PI / 180.0), 0, 1, 0.0)
         return transform
     }
+
     class func flipAnimation(_ view: UIView, completion: (() -> Void)?) {
         let angle = 180.0
         view.layer.transform = get3DTransformation(angle)
@@ -55,4 +67,5 @@ class AnimationClass {
                             completion?()
         }
     }
+
 }

--- a/Example/JTAppleCalendar iOS Example/AppDelegate.swift
+++ b/Example/JTAppleCalendar iOS Example/AppDelegate.swift
@@ -14,8 +14,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        return true
+    func application(_ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions:
+        [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+            return true
     }
 
     func applicationWillResignActive(_ application: UIApplication) {}

--- a/Example/JTAppleCalendar iOS Example/ExampleDateCells/DateCellCreatedWithCode/CodeCellView.swift
+++ b/Example/JTAppleCalendar iOS Example/ExampleDateCells/DateCellCreatedWithCode/CodeCellView.swift
@@ -13,6 +13,7 @@ class CodeCellView: JTAppleDayCellView {
     let bgColor = UIColor.red
     // Only override drawRect: if you perform custom drawing.
     // An empty implementation adversely affects performance during animation.
+
     override func draw(_ rect: CGRect) {
         let context = UIGraphicsGetCurrentContext()
         context?.setFillColor(red: 1.0, green: 0.5, blue: 0.0, alpha: 1.0)
@@ -23,4 +24,5 @@ class CodeCellView: JTAppleDayCellView {
         context?.addEllipse(in: CGRect(x: 0, y: 0, width: 25, height: 25))
         context?.strokePath()
     }
+
 }

--- a/Example/JTAppleCalendar iOS Example/ExampleDateCells/DateCellCreatedWithXIB/CellView.swift
+++ b/Example/JTAppleCalendar iOS Example/ExampleDateCells/DateCellCreatedWithXIB/CellView.swift
@@ -131,7 +131,7 @@ class AnimationView: UIView {
         }
     }
     func animateWithFadeEffect(withCompletionHandler completionHandler:(() -> Void)?) {
-        let viewAnimation = AnimationClass.FadeOutEffect()
+        let viewAnimation = AnimationClass.fadeOutEffect()
         viewAnimation(self) { _ in
             completionHandler?()
         }

--- a/Example/JTAppleCalendar iOS Example/ExampleSectionHeaders/HeaderAsClass/CodePinkSectionHeaderView.swift
+++ b/Example/JTAppleCalendar iOS Example/ExampleSectionHeaders/HeaderAsClass/CodePinkSectionHeaderView.swift
@@ -9,8 +9,7 @@
 import JTAppleCalendar
 
 class CodePinkSectionHeaderView: JTAppleHeaderView {
-     // Only override drawRect: if you perform custom drawing.
-     // An empty implementation adversely affects performance during animation.
+
      override func draw(_ rect: CGRect) {
         let context = UIGraphicsGetCurrentContext()!
         context.setFillColor(red: 1.0, green: 0.5, blue: 0.0, alpha: 1.0)
@@ -21,4 +20,5 @@ class CodePinkSectionHeaderView: JTAppleHeaderView {
         context.addEllipse(in: CGRect(x: 0, y: 0, width: 25, height: 25))
         context.strokePath()
      }
+
 }

--- a/Example/JTAppleCalendar iOS Example/ExampleSectionHeaders/HeaderAsClass/CodeWhiteSectionHeaderView.swift
+++ b/Example/JTAppleCalendar iOS Example/ExampleSectionHeaders/HeaderAsClass/CodeWhiteSectionHeaderView.swift
@@ -11,14 +11,16 @@ import JTAppleCalendar
 class CodeWhiteSectionHeaderView: JTAppleHeaderView {
     // Only override drawRect: if you perform custom drawing.
     // An empty implementation adversely affects performance during animation.
+
     override func draw(_ rect: CGRect) {
         let context = UIGraphicsGetCurrentContext()!
         context.setFillColor(red: 1.0, green: 2.5, blue: 0.3, alpha: 1.0)
-        let r1 = CGRect(x: 0, y: 0, width: 25, height: 25);         // Size
+        let r1 = CGRect(x: 0, y: 0, width: 25, height: 25)         // Size
         context.addRect(r1)
         context.fillPath()
         context.setStrokeColor(red: 1.0, green: 1.0, blue: 0.5, alpha: 1.0)
         context.addEllipse(in: CGRect(x: 0, y: 0, width: 25, height: 25))
         context.strokePath()
     }
+
 }

--- a/Example/JTAppleCalendar iOS Example/ViewController.swift
+++ b/Example/JTAppleCalendar iOS Example/ViewController.swift
@@ -9,9 +9,10 @@
 import JTAppleCalendar
 
 class ViewController: UIViewController {
+
     @IBOutlet weak var calendarView: JTAppleCalendarView!
     @IBOutlet weak var monthLabel: UILabel!
-    
+
     @IBOutlet var numbers: [UIButton]!
     @IBOutlet var headers: [UIButton]!
     @IBOutlet var directions: [UIButton]!
@@ -23,26 +24,30 @@ class ViewController: UIViewController {
 
     var numberOfRows = 6
     let formatter = DateFormatter()
-    var testCalendar: Calendar! = Calendar(identifier: Calendar.Identifier.gregorian)
+    var testCalendar = Calendar(identifier: Calendar.Identifier.gregorian)
     var generateInDates = true
     var generateOutDates: OutDateCellGeneration = .tillEndOfGrid
     let firstDayOfWeek: DaysOfWeek = .sunday
     let disabledColor = UIColor.lightGray
     let enabledColor = UIColor.blue
     let dateCellSize: CGFloat? = nil
-    
+
     @IBAction func changeToRow(_ sender: UIButton) {
         numberOfRows = Int(sender.title(for: .normal)!)!
-        
-        for aButton in numbers { aButton.tintColor = disabledColor }
+
+        for aButton in numbers {
+            aButton.tintColor = disabledColor
+        }
         sender.tintColor = enabledColor
         calendarView.reloadData()
     }
-    
+
     @IBAction func changeDirection(_ sender: UIButton) {
-        for aButton in directions { aButton.tintColor = disabledColor }
+        for aButton in directions {
+            aButton.tintColor = disabledColor
+        }
         sender.tintColor = enabledColor
-        
+
         if sender.title(for: .normal)! == "HorizontalCalendar" {
             calendarView.direction = .horizontal
             calendarView.itemSize = nil
@@ -52,19 +57,26 @@ class ViewController: UIViewController {
         }
         calendarView.reloadData()
     }
+
     @IBAction func headers(_ sender: UIButton) {
-        for aButton in headers { aButton.tintColor = disabledColor }
+        for aButton in headers {
+            aButton.tintColor = disabledColor
+        }
         sender.tintColor = enabledColor
-        
+
         if sender.title(for: .normal)! == "HeadersOn" {
-            calendarView.registerHeaderView(xibFileNames: ["PinkSectionHeaderView", "WhiteSectionHeaderView"])
+            calendarView.registerHeaderView(xibFileNames:
+                ["PinkSectionHeaderView", "WhiteSectionHeaderView"])
         } else {
             calendarView.unregisterHeaders()
         }
         calendarView.reloadData()
     }
+
     @IBAction func outDateGeneration(_ sender: UIButton) {
-        for aButton in outDates { aButton.tintColor = disabledColor }
+        for aButton in outDates {
+            aButton.tintColor = disabledColor
+        }
         sender.tintColor = enabledColor
 
         switch sender.title(for: .normal)! {
@@ -80,8 +92,11 @@ class ViewController: UIViewController {
         calendarView.reloadData()
 
     }
+
     @IBAction func inDateGeneration(_ sender: UIButton) {
-        for aButton in inDates { aButton.tintColor = disabledColor }
+        for aButton in inDates {
+            aButton.tintColor = disabledColor
+        }
         sender.tintColor = enabledColor
 
         switch sender.title(for: .normal)! {
@@ -92,140 +107,199 @@ class ViewController: UIViewController {
         default:
             break
         }
-        
+
         calendarView.reloadData()
     }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         formatter.dateFormat = "yyyy MM dd"
         testCalendar.timeZone = TimeZone(abbreviation: "GMT")!
-        
+
         // Setting up your dataSource and delegate is manditory
-        //_____________________________________________________________________________________________
+        // ___________________________________________________________________
         calendarView.delegate = self
         calendarView.dataSource = self
-        
+
 //        calendarView.direction = .vertical
-        //_____________________________________________________________________________________________
+        // ___________________________________________________________________
         // Registering your cells is manditory
-        //_____________________________________________________________________________________________
+        // ___________________________________________________________________
         calendarView.registerCellViewXib(file: "CellView")
-        calendarView.registerHeaderView(xibFileNames: ["PinkSectionHeaderView", "WhiteSectionHeaderView"])
-        
+        calendarView.registerHeaderView(xibFileNames:
+            ["PinkSectionHeaderView", "WhiteSectionHeaderView"])
+
 //        calendarView.itemSize = 25
         calendarView.cellInset = CGPoint(x: 0, y: 0)
         calendarView.allowsMultipleSelection = true
 
 //        calendarView.scrollingMode = .nonStopToCell(withResistance: 0.75)
-    
+
         let currentDate = self.calendarView.dateSegment()
-        self.setupViewsOfCalendar(currentDate.range.start, endDate: currentDate.range.end, month: currentDate.month)
-    
+        self.setupViewsOfCalendar(
+            currentDate.range.start,
+            endDate: currentDate.range.end,
+            month: currentDate.month
+        )
     }
+
     @IBAction func selectDate(_ sender: AnyObject?) {
         let fromDate = formatter.date(from: selectFrom.text!)!
         let toDate = formatter.date(from: selectTo.text!)!
         self.calendarView.selectDates(from: fromDate, to: toDate)
     }
+
     @IBAction func scrollToDate(_ sender: AnyObject?) {
         let text = scrollDate.text!
         let date = formatter.date(from: text)!
         calendarView.scrollToDate(date)
     }
+
     @IBAction func printSelectedDates() {
         print("\nSelected dates --->")
         for date in calendarView.selectedDates {
             print(formatter.string(from: date))
         }
     }
+
     @IBAction func resize(_ sender: UIButton) {
-        calendarView.frame = CGRect(x: calendarView.frame.origin.x, y: calendarView.frame.origin.y, width: calendarView.frame.width, height: calendarView.frame.height - 50)
-        
+        calendarView.frame = CGRect(
+            x: calendarView.frame.origin.x,
+            y: calendarView.frame.origin.y,
+            width: calendarView.frame.width,
+            height: calendarView.frame.height - 50
+        )
     }
+
     @IBAction func reloadCalendar(_ sender: UIButton) {
         calendarView.reloadData()
     }
+
     @IBAction func next(_ sender: UIButton) {
-        self.calendarView.scrollToNextSegment() {
+        self.calendarView.scrollToNextSegment {
             let currentSegmentDates = self.calendarView.dateSegment()
-            self.setupViewsOfCalendar(currentSegmentDates.range.start, endDate: currentSegmentDates.range.end, month: currentSegmentDates.month)
+            self.setupViewsOfCalendar(
+                currentSegmentDates.range.start,
+                endDate: currentSegmentDates.range.end,
+                month: currentSegmentDates.month
+            )
         }
     }
+
     @IBAction func previous(_ sender: UIButton) {
-        self.calendarView.scrollToPreviousSegment() {
+        self.calendarView.scrollToPreviousSegment {
             let currentSegmentDates = self.calendarView.dateSegment()
-            self.setupViewsOfCalendar(currentSegmentDates.range.start, endDate: currentSegmentDates.range.end, month: currentSegmentDates.month)
+            self.setupViewsOfCalendar(currentSegmentDates.range.start,
+                                      endDate: currentSegmentDates.range.end,
+                                      month: currentSegmentDates.month)
         }
     }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
     }
+
     func setupViewsOfCalendar(_ startDate: Date, endDate: Date, month: Int) {
-        let monthName = DateFormatter().monthSymbols[(month-1) % 12] // 0 indexed array
+        let monthName = DateFormatter().monthSymbols[(month-1) % 12]
+        // 0 indexed array
         let year = Calendar.current.component(.year, from: startDate)
         monthLabel.text = monthName + " " + String(year)
     }
+
 }
 
 // MARK : JTAppleCalendarDelegate
-extension ViewController: JTAppleCalendarViewDataSource, JTAppleCalendarViewDelegate {
-    func configureCalendar(_ calendar: JTAppleCalendarView) -> ConfigurationParameters {
-        let startDate = formatter.date(from: "2016 02 01")!
-        let endDate = formatter.date(from: "2016 10 01")!
-        let calendar = Calendar.current
-        
+extension ViewController: JTAppleCalendarViewDelegate,
+                          JTAppleCalendarViewDataSource {
 
-        let parameters = ConfigurationParameters(startDate: startDate,
-                                                 endDate: endDate,
-                                                 numberOfRows: numberOfRows,
-                                                 calendar: calendar,
-                                                 generateInDates: generateInDates,
-                                                 generateOutDates: generateOutDates,
-                                                 firstDayOfWeek: firstDayOfWeek)
-        return parameters
+    func configureCalendar(_ calendar: JTAppleCalendarView) ->
+        ConfigurationParameters {
+            let startDate = formatter.date(from: "2016 02 01")!
+            let endDate = formatter.date(from: "2016 10 01")!
+            let calendar = Calendar.current
+
+
+            let parameters = ConfigurationParameters(
+                startDate: startDate,
+                endDate: endDate,
+                numberOfRows: numberOfRows,
+                calendar: calendar,
+                generateInDates: generateInDates,
+                generateOutDates: generateOutDates,
+                firstDayOfWeek: firstDayOfWeek
+            )
+            return parameters
     }
-    func calendar(_ calendar: JTAppleCalendarView, willDisplayCell cell: JTAppleDayCellView, date: Date, cellState: CellState) {
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willDisplayCell cell: JTAppleDayCellView,
+                  date: Date, cellState: CellState) {
         (cell as? CellView)?.setupCellBeforeDisplay(cellState, date: date)
     }
-    func calendar(_ calendar: JTAppleCalendarView, didDeselectDate date: Date, cell: JTAppleDayCellView?, cellState: CellState) {
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didDeselectDate date: Date,
+                  cell: JTAppleDayCellView?, cellState: CellState) {
         (cell as? CellView)?.cellSelectionChanged(cellState)
     }
-    func calendar(_ calendar: JTAppleCalendarView, didSelectDate date: Date, cell: JTAppleDayCellView?, cellState: CellState) {
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didSelectDate date: Date,
+                  cell: JTAppleDayCellView?, cellState: CellState) {
         (cell as? CellView)?.cellSelectionChanged(cellState)
 //        printSelectedDates()
     }
+
     // NOTICE: this function is not needed for iOS 10. It will not be called
-    func calendar(_ calendar: JTAppleCalendarView, willResetCell cell: JTAppleDayCellView) {
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willResetCell cell: JTAppleDayCellView) {
         (cell as? CellView)?.selectedView.isHidden = true
     }
-    func calendar(_ calendar: JTAppleCalendarView, didScrollToDateSegmentFor range: (start: Date, end: Date), belongingTo month: Int, rows: Int) {
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didScrollToDateSegmentFor range: (start: Date, end: Date),
+                  belongingTo month: Int, rows: Int) {
         setupViewsOfCalendar(range.start, endDate: range.end, month: month)
     }
-    func calendar(_ calendar: JTAppleCalendarView, sectionHeaderIdentifierFor range: (start: Date, end: Date), belongingTo month: Int) -> String {
-        if month % 2 > 0 {
-            return "WhiteSectionHeaderView"
-        }
-        return "PinkSectionHeaderView"
+
+    func calendar(_ calendar: JTAppleCalendarView,
+        sectionHeaderIdentifierFor range: (start: Date, end: Date),
+        belongingTo month: Int) -> String {
+            if month % 2 > 0 {
+                return "WhiteSectionHeaderView"
+            }
+            return "PinkSectionHeaderView"
     }
-    func calendar(_ calendar: JTAppleCalendarView, sectionHeaderSizeFor range: (start: Date, end: Date), belongingTo month: Int) -> CGSize {
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  sectionHeaderSizeFor range: (start: Date, end: Date),
+                  belongingTo month: Int) -> CGSize {
         if month % 2 > 0 {
             return CGSize(width: 200, height: 50)
         } else {
-            return CGSize(width: 200, height: 100) // Yes you can have different size headers
+            // Yes you can have different size headers
+            return CGSize(width: 200, height: 100)
         }
     }
-    func calendar(_ calendar: JTAppleCalendarView, willDisplaySectionHeader header: JTAppleHeaderView, range: (start: Date, end: Date), identifier: String) {
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willDisplaySectionHeader header: JTAppleHeaderView,
+                  range: (start: Date, end: Date), identifier: String) {
         switch identifier {
         case "WhiteSectionHeaderView":
-            let headerCell = (header as? WhiteSectionHeaderView)
+            let headerCell = header as? WhiteSectionHeaderView
             headerCell?.title.text = "Design multiple headers"
         default:
-            let headerCell = (header as? PinkSectionHeaderView)
+            let headerCell = header as? PinkSectionHeaderView
             headerCell?.title.text = "In any color or size you want"
         }
     }
+
 }
-func delayRunOnMainThread(_ delay: Double, closure:@escaping () -> ()) {
+
+func delayRunOnMainThread(_ delay: Double, closure: @escaping () -> ()) {
     DispatchQueue.main.asyncAfter(
-        deadline: DispatchTime.now() + Double(Int64(delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
+        deadline: DispatchTime.now() +
+            Double(Int64(delay * Double(NSEC_PER_SEC))) /
+            Double(NSEC_PER_SEC), execute: closure)
 }

--- a/JTAppleCalendar.xcodeproj/project.pbxproj
+++ b/JTAppleCalendar.xcodeproj/project.pbxproj
@@ -457,6 +457,7 @@
 				6B60DEB81D5BDA46009174A2 /* Frameworks */,
 				6B60DEB91D5BDA46009174A2 /* Headers */,
 				6B60DEBA1D5BDA46009174A2 /* Resources */,
+				A6DEF96A2FE3F7CE47390D26 /* Tailor */,
 			);
 			buildRules = (
 			);
@@ -475,6 +476,7 @@
 				6B60DEC61D5BDA74009174A2 /* Frameworks */,
 				6B60DEC71D5BDA74009174A2 /* Headers */,
 				6B60DEC81D5BDA74009174A2 /* Resources */,
+				65B34C321DA622B7005C3583 /* Tailor */,
 			);
 			buildRules = (
 			);
@@ -511,7 +513,7 @@
 				6B60DF081D5BE834009174A2 /* Frameworks */,
 				6B60DF091D5BE834009174A2 /* Resources */,
 				6B2EA03D1D644A8B006DAD00 /* Embed Frameworks */,
-				6BA9245C1D8FA1CF00415488 /* ShellScript */,
+				6BA9245C1D8FA1CF00415488 /* Tailor */,
 			);
 			buildRules = (
 			);
@@ -549,6 +551,7 @@
 				6B60DF4F1D5BFE41009174A2 /* Frameworks */,
 				6B60DF501D5BFE41009174A2 /* Resources */,
 				6B2EA0421D644ABD006DAD00 /* Embed Frameworks */,
+				65B34C331DA622FD005C3583 /* Tailor */,
 			);
 			buildRules = (
 			);
@@ -675,18 +678,61 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6BA9245C1D8FA1CF00415488 /* ShellScript */ = {
+		65B34C321DA622B7005C3583 /* Tailor */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 8;
+			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = Tailor;
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 1;
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi";
+			shellScript = "if hash tailor 2>/dev/null; then\ntailor -l 78 #--max-name-length 30\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+		};
+		65B34C331DA622FD005C3583 /* Tailor */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Tailor;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if hash tailor 2>/dev/null; then\ntailor -l 78 #--max-name-length 30\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+		};
+		6BA9245C1D8FA1CF00415488 /* Tailor */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 12;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Tailor;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if hash tailor 2>/dev/null; then\ntailor -l 78 #--max-name-length 30\nelse\necho \"warning: Please install Tailor from https://tailor.sh\"\nfi";
+		};
+		A6DEF96A2FE3F7CE47390D26 /* Tailor */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = Tailor;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if hash tailor 2>/dev/null; then\n    tailor -l 78 #--max-name-length 30\nelse\n  echo \"warning: Please install Tailor from https://tailor.sh\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following structure was returned when a cell is about to be displayed.
 
 ```swift
     public enum DateOwner: Int {
-        case ThisMonth = 0, PreviousMonthWithinBoundary, PreviousMonthOutsideBoundary, FollowingMonthWithinBoundary, FollowingMonthOutsideBoundary
+        case thisMonth = 0, previousMonthWithinBoundary, previousMonthOutsideBoundary, followingMonthWithinBoundary, followingMonthOutsideBoundary
     }
 ```
 

--- a/Sources/CalendarEnums.swift
+++ b/Sources/CalendarEnums.swift
@@ -8,15 +8,20 @@
 
 /// Describes the types of out-date cells to be generated.
 public enum OutDateCellGeneration {
-    /// tillEndOfRow will generate dates till it reaches the end of a row. 
-    /// endOfGrid will continue generating until it has filled a 6x7 grid. Off-mode will generate no postdates
+    /// tillEndOfRow will generate dates till it reaches the end of a row.
+    /// endOfGrid will continue generating until it has filled a 6x7 grid.
+    /// Off-mode will generate no postdates
     case tillEndOfRow, tillEndOfGrid, off
 }
 
 /// Describes which month owns the date
 public enum DateOwner: Int {
     /// Describes which month owns the date
-    case thisMonth = 0, previousMonthWithinBoundary, previousMonthOutsideBoundary, followingMonthWithinBoundary, followingMonthOutsideBoundary
+    case thisMonth = 0,
+        previousMonthWithinBoundary,
+        previousMonthOutsideBoundary,
+        followingMonthWithinBoundary,
+        followingMonthOutsideBoundary
 }
 
 /// Selection position of a range-selected date cell
@@ -25,7 +30,8 @@ public enum SelectionRangePosition: Int {
     case left = 1, middle, right, full, none
 }
 
-/// Days of the week. By setting you calandar's first day of week, you can change which day is the first for the week. Sunday is by default.
+/// Days of the week. By setting you calandar's first day of week,
+/// you can change which day is the first for the week. Sunday is by default.
 public enum DaysOfWeek: Int {
     /// Days of the week.
     case sunday = 1, monday, tuesday, wednesday, thursday, friday, saturday
@@ -36,4 +42,3 @@ enum JTAppleCalendarViewSource {
     case fromType(AnyClass)
     case fromClassName(String, Bundle?)
 }
-

--- a/Sources/CalendarStructs.swift
+++ b/Sources/CalendarStructs.swift
@@ -9,12 +9,18 @@
 
 /// Describes which month the cell belongs to
 /// - ThisMonth: Cell belongs to the current month
-/// - PreviousMonthWithinBoundary: Cell belongs to the previous month. Previous month is included in the date boundary you have set in your delegate
-/// - PreviousMonthOutsideBoundary: Cell belongs to the previous month. Previous month is not included in the date boundary you have set in your delegate
-/// - FollowingMonthWithinBoundary: Cell belongs to the following month. Following month is included in the date boundary you have set in your delegate
-/// - FollowingMonthOutsideBoundary: Cell belongs to the following month. Following month is not included in the date boundary you have set in your delegate
-/// You can use these cell states to configure how you want your date cells to look.
-/// Eg. you can have the colors belonging to the month be in color black, while the colors of previous months be in color gray.
+/// - PreviousMonthWithinBoundary: Cell belongs to the previous month.
+/// Previous month is included in the date boundary you have set in your
+/// delegate - PreviousMonthOutsideBoundary: Cell belongs to the previous
+/// month. Previous month is not included in the date boundary you have set
+/// in your delegate - FollowingMonthWithinBoundary: Cell belongs to the
+/// following month. Following month is included in the date boundary you have
+/// set in your delegate - FollowingMonthOutsideBoundary: Cell belongs to the
+/// following month. Following month is not included in the date boundary you
+/// have set in your delegate You can use these cell states to configure how
+/// you want your date cells to look. Eg. you can have the colors belonging
+/// to the month be in color black, while the colors of previous months be in
+/// color gray.
 public struct CellState {
     /// returns true if a cell is selected
     public let isSelected: Bool
@@ -31,22 +37,25 @@ public struct CellState {
     /// returns the column in which the date cell appears visually
     public let column: () -> Int
     /// returns the section the date cell belongs to
-    public let dateSection: ()->(range: (start: Date, end: Date), month: Int, rowsForSection: Int)
-    /// returns the position of a selection in the event you wish to do range selection
+    public let dateSection: () ->
+        (range: (start: Date, end: Date), month: Int, rowsForSection: Int)
+    /// returns the position of a selection
+    /// in the event you wish to do range selection
     public let selectedPosition: () -> SelectionRangePosition
-    /// returns the cell frame. Useful if you wish to display something at the cell's frame/position
+    /// returns the cell frame.
+    /// Useful if you wish to display something at the cell's frame/position
     public var cell: () -> JTAppleDayCell?
 }
 
-/// Defines the parameters which configures the calendar. The following parameters are:
-/// - startDate: The start date boundary of your calendar
-/// - endDate: The end-date boundary of your calendar
-/// - numberOfRows: Number of rows you want to calendar to display per date section
-/// - calendar: Your Calendar() instance. You are responsible for PROPERLY configuring this to you region settings.
-/// All calendar calculations will be based on what you have setup here.
-/// - generateInDates: Set to true if you want pre-dates to be generated.
-/// - generateOutDates: Describes the types of out-date cells to be generated.
-/// - firstDayOfWeek: Sets the first day of week.
+/// Defines the parameters which configures the calendar. The following
+/// parameters are: - startDate: The start date boundary of your calendar -
+/// endDate: The end-date boundary of your calendar - numberOfRows: Number of
+/// rows you want to calendar to display per date section - calendar: Your
+/// Calendar() instance. You are responsible for PROPERLY configuring this to
+/// you region settings. All calendar calculations will be based on what you
+/// have setup here. - generateInDates: Set to true if you want pre-dates to
+/// be generated. - generateOutDates: Describes the types of out-date cells to
+/// be generated. - firstDayOfWeek: Sets the first day of week.
 public struct ConfigurationParameters {
     var startDate: Date
     var endDate: Date
@@ -74,29 +83,53 @@ public struct ConfigurationParameters {
 struct CalendarData {
     var months: [Month]
     var totalSections: Int
-    var monthMap: [Int:Int]
+    var monthMap: [Int: Int]
     var totalDays: Int
 }
 
 struct Month {
-    let startDayIndex: Int      // Start index day for the month. The start is total number of days of previous months
-    let startCellIndex: Int     // Start cell index for the month. The start is total number of cells of previous months
-    let sections: [Int]         // The total number of items in this array are the total number of sections. The actual number is the number of items in each section
+
+    // Start index day for the month.
+    // The start is total number of days of previous months
+    let startDayIndex: Int
+
+    // Start cell index for the month.
+    // The start is total number of cells of previous months
+    let startCellIndex: Int
+
+    // The total number of items in this array are the total number
+    // of sections. The actual number is the number of items in each section
+    let sections: [Int]
+
     let preDates: Int
+
     let postDates: Int
-    let sectionIndexMaps: [Int:Int] // Maps a section to the index in the total number of sections
-    let rows: Int                   // Number of rows for the month
+
+    // Maps a section to the index in the total number of sections
+    let sectionIndexMaps: [Int: Int]
+
+    // Number of rows for the month
+    let rows: Int
+
     // Return the total number of days for the represented month
     var numberOfDaysInMonth: Int {
-        get { return numberOfDaysInMonthGrid - preDates - postDates }
+        get {
+            return numberOfDaysInMonthGrid - preDates - postDates
+        }
     }
-    // Return the total number of day cells to generate for the represented month
+
+    // Return the total number of day cells
+    // to generate for the represented month
     var numberOfDaysInMonthGrid: Int {
-        get { return sections.reduce(0, +) }
+        get {
+            return sections.reduce(0, +)
+        }
     }
+
     var startSection: Int {
         return sectionIndexMaps.keys.min()!
     }
+
     // Return the section in which a day is contained
     func indexPath(forDay number: Int) -> IndexPath? {
         var variableNumber = number
@@ -106,13 +139,14 @@ struct Month {
             return retval
             }!
         let theSection = sectionIndexMaps.key(for: possibleSection)!
-        
-        let dateOfStartIndex = sections[0..<possibleSection].reduce(0, +) - preDates + 1
+
+        let dateOfStartIndex =
+            sections[0..<possibleSection].reduce(0, +) - preDates + 1
         let itemIndex = number - dateOfStartIndex
-        
+
         return IndexPath(item: itemIndex, section: theSection)
     }
-    
+
     // Return the number of rows for a section in the month
     func numberOfRows(for section: Int, developerSetRows: Int) -> Int {
         var retval: Int
@@ -121,7 +155,7 @@ struct Month {
         }
         let fullRows = rows / developerSetRows
         let partial = sections.count - fullRows
-        
+
         if theSection + 1 <= fullRows {
             retval = developerSetRows
         } else if fullRows == 0 && partial > 0 {
@@ -131,6 +165,7 @@ struct Month {
         }
         return retval
     }
+
     // Returns the maximum number of a rows for a completely full section
     func maxNumberOfRowsForFull(developerSetRows: Int) -> Int {
         var retval: Int
@@ -142,6 +177,7 @@ struct Month {
         }
         return retval
     }
+
 }
 
 struct DateConfigParameters {
@@ -155,10 +191,13 @@ struct DateConfigParameters {
 }
 
 struct JTAppleDateConfigGenerator {
+
     var parameters: DateConfigParameters?
     weak var delegate: JTAppleCalendarDelegateProtocol!
-    mutating func setupMonthInfoDataForStartAndEndDate(_ parameters: DateConfigParameters?)->
-        (months: [Month], monthMap: [Int:Int], totalSections: Int, totalDays: Int) {
+
+    mutating func setupMonthInfoDataForStartAndEndDate(
+        _ parameters: DateConfigParameters?) -> (months: [Month],
+        monthMap: [Int: Int], totalSections: Int, totalDays: Int) {
             self.parameters = parameters
             guard
                 var validParameters = parameters,
@@ -174,73 +213,111 @@ struct JTAppleDateConfigGenerator {
             default:
                 validParameters.numberOfRows = 6
             }
-            let differenceComponents = calendar.dateComponents([.month], from: startMonth, to: endMonth)
-            let numberOfMonths = differenceComponents.month! + 1 // if we are for example on the same month and the difference is 0 we still need 1 to display it
+            let differenceComponents = calendar.dateComponents(
+                [.month], from: startMonth, to: endMonth)
+            let numberOfMonths = differenceComponents.month! + 1
+            // if we are for example on the same month
+            // and the difference is 0 we still need 1 to display it
             var monthArray: [Month] = []
-            var monthIndexMap: [Int:Int] = [:]
+            var monthIndexMap: [Int: Int] = [:]
             var section = 0
             var startIndexForMonth = 0
             var startCellIndexForMonth = 0
             var totalDays = 0
-            let numberOfRowsPerSectionThatUserWants = validParameters.numberOfRows
+            let numberOfRowsPerSectionThatUserWants =
+                validParameters.numberOfRows
             // Number of sections in each month
-            //        let numberOfSectionsPerMonth = Int(ceil(Float(maxNumberOfRowsPerMonth)  / Float(validParameters.numberOfRows)))
-            // Section represents # of months. section is used as an offset to determine which month to calculate
+//            let numberOfSectionsPerMonth = Int(
+//                ceil(
+//                    Float(maxNumberOfRowsPerMonth)  /
+//                        Float(validParameters.numberOfRows)
+//                )
+//            )
+            // Section represents # of months. section is used as an offset
+            // to determine which month to calculate
             for monthIndex in 0 ..< numberOfMonths {
-                if let currentMonth = calendar.date(byAdding: .month, value: monthIndex, to: startMonth) {
-                    var numberOfDaysInMonthVariable = calendar.range(of: .day, in: .month, for: currentMonth)!.count
+                if let currentMonth = calendar.date(byAdding: .month,
+                                                    value: monthIndex,
+                                                    to: startMonth) {
+                    var numberOfDaysInMonthVariable = calendar.range(
+                        of: .day, in: .month, for: currentMonth)!.count
                     let numberOfDaysInMonthFixed = numberOfDaysInMonthVariable
                     var numberOfRowsToGenerateForCurrentMonth = 0
                     var numberOfPreDatesForThisMonth = 0
                     if delegate.preDatesAreGenerated() {
-                        numberOfPreDatesForThisMonth = delegate.numberOfPreDatesForMonth(currentMonth)
-                        numberOfDaysInMonthVariable += numberOfPreDatesForThisMonth
+                        numberOfPreDatesForThisMonth =
+                            delegate.numberOfPreDatesForMonth(currentMonth)
+                        numberOfDaysInMonthVariable +=
+                        numberOfPreDatesForThisMonth
                     }
-                    if /*validParameters.inCellGeneration == true &&*/ validParameters.outCellGeneration == .tillEndOfGrid {
-                        numberOfRowsToGenerateForCurrentMonth = maxNumberOfRowsPerMonth
+                    if // validParameters.inCellGeneration == true &&
+                        validParameters.outCellGeneration == .tillEndOfGrid {
+                            numberOfRowsToGenerateForCurrentMonth =
+                                maxNumberOfRowsPerMonth
                     } else {
-                        let actualNumberOfRowsForThisMonth = Int(ceil(Float(numberOfDaysInMonthVariable) / Float(maxNumberOfDaysInWeek)))
-                        numberOfRowsToGenerateForCurrentMonth = actualNumberOfRowsForThisMonth
+                        let actualNumberOfRowsForThisMonth =
+                            Int(ceil(Float(numberOfDaysInMonthVariable) /
+                                Float(maxNumberOfDaysInWeek)))
+                        numberOfRowsToGenerateForCurrentMonth =
+                        actualNumberOfRowsForThisMonth
                     }
                     var numberOfPostDatesForThisMonth = 0
                     let postGeneration = delegate.postDatesAreGenerated()
                     switch postGeneration {
                     case .tillEndOfGrid, .tillEndOfRow:
-                        numberOfPostDatesForThisMonth = maxNumberOfDaysInWeek * numberOfRowsToGenerateForCurrentMonth - (numberOfDaysInMonthFixed + numberOfPreDatesForThisMonth)
-                        numberOfDaysInMonthVariable += numberOfPostDatesForThisMonth
+                        numberOfPostDatesForThisMonth =
+                            maxNumberOfDaysInWeek *
+                            numberOfRowsToGenerateForCurrentMonth -
+                            (numberOfDaysInMonthFixed +
+                                numberOfPreDatesForThisMonth)
+                        numberOfDaysInMonthVariable +=
+                            numberOfPostDatesForThisMonth
                     default:
                         break
                     }
-                    //                let numberOfDaysInMonthFixed = numberOfDaysInMonthVariable
+                    // let numberOfDaysInMonthFixed =
+                    //     numberOfDaysInMonthVariable
                     var sectionsForTheMonth: [Int] = []
-                    var sectionIndexMaps: [Int:Int] = [:]
-                    for index in 0..<6 { // Max number of sections in the month
-                        if numberOfDaysInMonthVariable < 1 { break }
+                    var sectionIndexMaps: [Int: Int] = [:]
+                    for index in 0..<6 {
+                        // Max number of sections in the month
+                        if numberOfDaysInMonthVariable < 1 {
+                            break
+                        }
                         monthIndexMap[section] = monthIndex
                         sectionIndexMaps[section] = index
-                        var numberOfDaysInCurrentSection = numberOfRowsPerSectionThatUserWants * maxNumberOfDaysInWeek
-                        if numberOfDaysInCurrentSection > numberOfDaysInMonthVariable {
-                            numberOfDaysInCurrentSection = numberOfDaysInMonthVariable
-                            //                        assert(false)
+                        var numberOfDaysInCurrentSection =
+                            numberOfRowsPerSectionThatUserWants *
+                            maxNumberOfDaysInWeek
+                        if numberOfDaysInCurrentSection >
+                            numberOfDaysInMonthVariable {
+                                numberOfDaysInCurrentSection =
+                                    numberOfDaysInMonthVariable
+                                // assert(false)
                         }
                         totalDays += numberOfDaysInCurrentSection
-                        sectionsForTheMonth.append(numberOfDaysInCurrentSection)
-                        numberOfDaysInMonthVariable -= numberOfDaysInCurrentSection
+                        sectionsForTheMonth
+                            .append(numberOfDaysInCurrentSection)
+                        numberOfDaysInMonthVariable -=
+                            numberOfDaysInCurrentSection
                         section += 1
                     }
-                    monthArray.append(Month(startDayIndex: startIndexForMonth,
-                                            startCellIndex: startCellIndexForMonth,
-                                            sections: sectionsForTheMonth,
-                                            preDates: numberOfPreDatesForThisMonth,
-                                            postDates: numberOfPostDatesForThisMonth,
-                                            sectionIndexMaps: sectionIndexMaps,
-                                            rows: numberOfRowsToGenerateForCurrentMonth))
-                    startIndexForMonth     += numberOfDaysInMonthFixed
-                    startCellIndexForMonth += numberOfDaysInMonthFixed + numberOfPreDatesForThisMonth + numberOfPostDatesForThisMonth
+                    monthArray.append(Month(
+                        startDayIndex: startIndexForMonth,
+                        startCellIndex: startCellIndexForMonth,
+                        sections: sectionsForTheMonth,
+                        preDates: numberOfPreDatesForThisMonth,
+                        postDates: numberOfPostDatesForThisMonth,
+                        sectionIndexMaps: sectionIndexMaps,
+                        rows: numberOfRowsToGenerateForCurrentMonth
+                    ))
+                    startIndexForMonth += numberOfDaysInMonthFixed
+                    startCellIndexForMonth += numberOfDaysInMonthFixed +
+                        numberOfPreDatesForThisMonth +
+                    numberOfPostDatesForThisMonth
                 }
             }
             return (monthArray, monthIndexMap, section, totalDays)
     }
+
 }
-
-

--- a/Sources/GlobalFunctionsAndExtensions.swift
+++ b/Sources/GlobalFunctionsAndExtensions.swift
@@ -6,34 +6,50 @@
 //
 //
 
-func delayRunOnMainThread(_ delay: Double, closure:@escaping () -> ()) {
+func delayRunOnMainThread(_ delay: Double, closure: @escaping () -> ()) {
     DispatchQueue.main.asyncAfter(
-        deadline: DispatchTime.now() + Double(Int64(delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
+        deadline: DispatchTime.now() +
+            Double(Int64(delay * Double(NSEC_PER_SEC))) /
+            Double(NSEC_PER_SEC), execute: closure)
 }
 
-func delayRunOnGlobalThread(_ delay: Double, qos: DispatchQoS.QoSClass, closure:@escaping () -> ()) {
+func delayRunOnGlobalThread(_ delay: Double,
+                            qos: DispatchQoS.QoSClass,
+                            closure: @escaping () -> ()) {
     DispatchQueue.global(qos: qos).asyncAfter(
-        deadline: DispatchTime.now() + Double(Int64(delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC), execute: closure)
+        deadline: DispatchTime.now() +
+            Double(Int64(delay * Double(NSEC_PER_SEC))) /
+            Double(NSEC_PER_SEC), execute: closure
+    )
 }
 
 extension Date {
-    static func startOfMonth(for date: Date, using calendar: Calendar) -> Date? {
-        let dayOneComponents = calendar.dateComponents([.era, .year, .month], from: date)
+
+    static func startOfMonth(for date: Date,
+                             using calendar: Calendar) -> Date? {
+        let dayOneComponents =
+            calendar.dateComponents([.era, .year, .month], from: date)
         return calendar.date(from: dayOneComponents)
     }
-    static func endOfMonth(for date: Date, using calendar: Calendar) -> Date? {
-        var lastDayComponents = calendar.dateComponents([.era, .year, .month], from: date)
+
+    static func endOfMonth(for date: Date,
+                           using calendar: Calendar) -> Date? {
+        var lastDayComponents =
+            calendar.dateComponents([.era, .year, .month], from: date)
         lastDayComponents.month = lastDayComponents.month! + 1
         lastDayComponents.day = 0
         return calendar.date(from: lastDayComponents)
     }
+
 }
 
 extension Dictionary where Value: Equatable {
+
     func key(for value: Value) -> Key? {
         guard let index = index(where: { $0.1 == value }) else {
             return nil
         }
         return self[index].0
     }
+
 }

--- a/Sources/JTAppleCalendarDelegateProtocol.swift
+++ b/Sources/JTAppleCalendarDelegateProtocol.swift
@@ -12,13 +12,13 @@ protocol JTAppleCalendarDelegateProtocol: class {
     var registeredHeaderViews: [JTAppleCalendarViewSource] {get set}
     var cachedConfiguration: ConfigurationParameters {get set}
     var monthInfo: [Month] {get set}
-    var monthMap: [Int:Int] {get set}
+    var monthMap: [Int: Int] {get set}
     var totalDays: Int {get}
     func numberOfRows() -> Int
     func cachedDate() -> (start: Date, end: Date, calendar: Calendar)
     func numberOfMonthsInCalendar() -> Int
     func numberOfPreDatesForMonth(_ month: Date) -> Int
-    
+
     func referenceSizeForHeaderInSection(_ section: Int) -> CGSize
     func firstDayIndexForMonth(_ date: Date) -> Int
     func rowsAreStatic() -> Bool
@@ -27,29 +27,40 @@ protocol JTAppleCalendarDelegateProtocol: class {
 }
 
 extension JTAppleCalendarView: JTAppleCalendarDelegateProtocol {
-    
+
     func cachedDate() -> (start: Date, end: Date, calendar: Calendar) {
-        return (start: cachedConfiguration.startDate, end: cachedConfiguration.endDate, calendar: cachedConfiguration.calendar)
+        return (start: cachedConfiguration.startDate,
+                end: cachedConfiguration.endDate,
+                calendar: cachedConfiguration.calendar)
     }
+
     func numberOfRows() -> Int {
         return cachedConfiguration.numberOfRows
     }
+
     func numberOfMonthsInCalendar() -> Int {
         return numberOfMonths
     }
+
     func numberOfPreDatesForMonth(_ month: Date) -> Int {
         return firstDayIndexForMonth(month)
     }
+
     func preDatesAreGenerated() -> Bool {
         return cachedConfiguration.generateInDates
     }
+
     func postDatesAreGenerated() -> OutDateCellGeneration {
         return cachedConfiguration.generateOutDates
     }
+
     func referenceSizeForHeaderInSection(_ section: Int) -> CGSize {
         return calendarViewHeaderSizeForSection(section)
     }
+
     func rowsAreStatic() -> Bool {
-        return cachedConfiguration.generateInDates == true && cachedConfiguration.generateOutDates == .tillEndOfGrid
+        return cachedConfiguration.generateInDates == true &&
+            cachedConfiguration.generateOutDates == .tillEndOfGrid
     }
+
 }

--- a/Sources/JTAppleCalendarLayout.swift
+++ b/Sources/JTAppleCalendarLayout.swift
@@ -8,46 +8,83 @@
 
 
 /// Base class for the Horizontal layout
-open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutProtocol {
+open class JTAppleCalendarLayout: UICollectionViewLayout,
+                                    JTAppleCalendarLayoutProtocol {
     let errorDelta: CGFloat = 0.0000001
     var itemSize: CGSize = CGSize.zero
     var headerReferenceSize: CGSize = CGSize.zero
     var scrollDirection: UICollectionViewScrollDirection = .horizontal
-    var maxSections: Int { get { return monthMap.count } }
+    var maxSections: Int {
+        get {
+            return monthMap.count
+        }
+    }
     var maxMissCount: Int = 0
-    var cellCache: [Int:[UICollectionViewLayoutAttributes]] = [:]
-    var headerCache: [Int:UICollectionViewLayoutAttributes] = [:]
+    var cellCache: [Int: [UICollectionViewLayoutAttributes]] = [:]
+    var headerCache: [Int: UICollectionViewLayoutAttributes] = [:]
     var sectionSize: [CGFloat] = []
     var lastWrittenCellAttribute: UICollectionViewLayoutAttributes?
-    var thereAreHeaders: Bool { get { return delegate.registeredHeaderViews.count > 0}}
-    var monthData: [Month] { get { return delegate.monthInfo } }
-    var monthMap: [Int:Int] { get { return delegate.monthMap } }
-    var numberOfRows: Int {get { return delegate.numberOfRows()} }
+    var thereAreHeaders: Bool {
+        get {
+            return delegate.registeredHeaderViews.count > 0
+        }
+    }
+    var monthData: [Month] {
+        get {
+            return delegate.monthInfo
+        }
+    }
+    var monthMap: [Int: Int] {
+        get {
+            return delegate.monthMap
+        }
+    }
+    var numberOfRows: Int {
+        get {
+            return delegate.numberOfRows()
+        }
+    }
     var stride: CGFloat = 0
     weak var delegate: JTAppleCalendarDelegateProtocol!
-    var currentHeader: (section: Int, size: CGSize)? // Tracks the current header size
-    var currentCell: (section: Int, itemSize: CGSize)? // Tracks the current cell size
+    var currentHeader: (section: Int, size: CGSize)?
+    // Tracks the current header size
+
+    var currentCell: (section: Int, itemSize: CGSize)?
+    // Tracks the current cell size
+
     var contentHeight: CGFloat = 0 // Content height of calendarView
     var contentWidth: CGFloat = 0 // Content wifth of calendarView
     var xCellOffset: CGFloat = 0
     var yCellOffset: CGFloat = 0
-    var daysInSection: [Int:Int] = [:] // Caching
+    var daysInSection: [Int: Int] = [:] // Caching
     init(withDelegate delegate: JTAppleCalendarDelegateProtocol) {
         super.init()
         self.delegate = delegate
     }
+
     /// Tells the layout object to update the current layout.
     open override func prepare() {
         print("Prepare was called")
-        if !cellCache.isEmpty { return }
+        if !cellCache.isEmpty {
+            return
+        }
         print("All was recreated!! ")
-        maxMissCount = scrollDirection == .horizontal ? maxNumberOfRowsPerMonth : maxNumberOfDaysInWeek
-        if scrollDirection == .vertical { verticalStuff() } else { horizontalStuff() }
-        
-        // Get rid of header data if dev didnt register headers. The were used for calculation but are not needed to be displayed
-        if !thereAreHeaders { headerCache.removeAll() }
+        maxMissCount = scrollDirection == .horizontal ?
+            maxNumberOfRowsPerMonth : maxNumberOfDaysInWeek
+        if scrollDirection == .vertical {
+            verticalStuff()
+        } else {
+            horizontalStuff()
+        }
+
+        // Get rid of header data if dev didnt register headers.
+        // The were used for calculation but are not needed to be displayed
+        if !thereAreHeaders {
+            headerCache.removeAll()
+        }
         daysInSection.removeAll() // Clear chache
     }
+
     func horizontalStuff() {
         var section = 0
         var rowNumber = 0
@@ -57,13 +94,15 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
             for numberOfDaysInCurrentSection in aMonth.sections {
                 // Generate and cache the headers
                 let sectionIndexPath = IndexPath(item: 0, section: section)
-                if let aHeaderAttr = layoutAttributesForSupplementaryView(ofKind: UICollectionElementKindSectionHeader, at: sectionIndexPath) {
-                    headerCache[section] = aHeaderAttr
-                    if thereAreHeaders {
-                        contentWidth += aHeaderAttr.frame.width
-                        yCellOffset = aHeaderAttr.frame.height
+                if let aHeaderAttr = layoutAttributesForSupplementaryView(
+                    ofKind: UICollectionElementKindSectionHeader,
+                    at: sectionIndexPath) {
+                        headerCache[section] = aHeaderAttr
+                        if thereAreHeaders {
+                            contentWidth += aHeaderAttr.frame.width
+                            yCellOffset = aHeaderAttr.frame.height
+                        }
                     }
-                }
                 // Generate and cache the cells
                 for item in 0..<numberOfDaysInCurrentSection {
                     let indexPath = IndexPath(item: item, section: section)
@@ -74,32 +113,47 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
                         cellCache[section]!.append(attribute)
                         lastWrittenCellAttribute = attribute
                         xCellOffset += attribute.frame.width
-                        
+
                         if thereAreHeaders {
                             headerGuide += 1
-                            if numberOfDaysInCurrentSection - 1 == item || headerGuide % 7 == 0 { // We are at the last item in the section && if we have headers
-                                headerGuide = 0
-                                xCellOffset = 0
-                                yCellOffset += attribute.frame.height
+                            if numberOfDaysInCurrentSection - 1 == item ||
+                                headerGuide % 7 == 0 {
+                                // We are at the last item in the section
+                                // && if we have headers
+                                    headerGuide = 0
+                                    xCellOffset = 0
+                                    yCellOffset += attribute.frame.height
                             }
                         } else {
                             totalDayCounter += 1
-                            if totalDayCounter >= delegate.totalDays { // If we are at the last item and we are also ona partial (because we were not at end of row)
-                                contentWidth += lastWrittenCellAttribute!.frame.width * 7
+                            if totalDayCounter >= delegate.totalDays {
+                                // If we are at the last item and we are
+                                // also ona partial (because we were not
+                                // at end of row)
+                                contentWidth += lastWrittenCellAttribute!
+                                    .frame.width * 7
                             } else if totalDayCounter % 7 == 0 {
                                 xCellOffset = 0
-                                if rowNumber + 1 == numberOfRows { // If we are at the end of a virtual section
+                                if rowNumber + 1 == numberOfRows {
+                                    // If we are at the end of
+                                    // a virtual section
                                     yCellOffset = 0
-                                    contentWidth += lastWrittenCellAttribute!.frame.width * 7
+                                    contentWidth += lastWrittenCellAttribute!
+                                        .frame.width * 7
                                     stride = contentWidth
                                     rowNumber = 0
-                                } else if numberOfDaysInCurrentSection - 1 == item {
-                                    xCellOffset = 0
-                                    yCellOffset = 0
-                                    contentWidth += lastWrittenCellAttribute!.frame.width * 7
-                                    stride = contentWidth
-                                    rowNumber = 0
-                                } else { // We we are simply only at the end of a row
+                                } else if numberOfDaysInCurrentSection - 1 ==
+                                    item {
+                                        xCellOffset = 0
+                                        yCellOffset = 0
+                                        contentWidth +=
+                                            lastWrittenCellAttribute!
+                                                .frame.width * 7
+                                        stride = contentWidth
+                                        rowNumber = 0
+                                } else {
+                                    // We we are simply only at
+                                    // the end of a row
                                     yCellOffset += attribute.frame.height
                                     rowNumber += 1
                                 }
@@ -117,8 +171,8 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
         }
         contentHeight = self.collectionView!.bounds.size.height
     }
-    
-    func verticalStuff () {
+
+    func verticalStuff() {
         var section = 0
         var totalDayCounter = 0
         var headerGuide = 0
@@ -127,7 +181,11 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
                 // Generate and cache the headers
                 let sectionIndexPath = IndexPath(item: 0, section: section)
                 if thereAreHeaders {
-                    if let aHeaderAttr = layoutAttributesForSupplementaryView(ofKind: UICollectionElementKindSectionHeader, at: sectionIndexPath) {
+                    if let aHeaderAttr =
+                        layoutAttributesForSupplementaryView(
+                            ofKind: UICollectionElementKindSectionHeader,
+                            at: sectionIndexPath) {
+
                         headerCache[section] = aHeaderAttr
                         yCellOffset += aHeaderAttr.frame.height
                         contentHeight += aHeaderAttr.frame.height
@@ -146,13 +204,15 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
                         xCellOffset += attribute.frame.width
                         if thereAreHeaders {
                             headerGuide += 1
-                            if headerGuide % 7 == 0 || numberOfDaysInCurrentSection - 1 == item { // We are at the last item in the section && if we have headers
-                                headerGuide = 0 
+                            if headerGuide % 7 == 0 ||
+                                numberOfDaysInCurrentSection - 1 == item {
+                                // We are at the last item in the
+                                // section && if we have headers
+                                headerGuide = 0
                                 xCellOffset = 0
                                 yCellOffset += attribute.frame.height
                                 contentHeight += attribute.frame.height
                             }
-                            
                         } else {
                             totalDayCounter += 1
                             if totalDayCounter % 7 == 0 {
@@ -160,7 +220,6 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
                                 yCellOffset += attribute.frame.height
                                 contentHeight += attribute.frame.height
                             }
-                            
                         }
                     }
                 }
@@ -171,108 +230,169 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
         }
         contentWidth = self.collectionView!.bounds.size.width
     }
-    /// Returns the width and height of the collection view’s contents. The width and height of the collection view’s contents.
+
+    /// Returns the width and height of the collection view’s contents.
+    /// The width and height of the collection view’s contents.
     open override var collectionViewContentSize: CGSize {
         return CGSize(width: contentWidth, height: contentHeight)
     }
-    /// Returns the layout attributes for all of the cells and views in the specified rectangle.
-    override open func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
-        let startSectionIndex = startIndexFrom(rectOrigin: rect.origin)
-        // keep looping until there were no interception rects
-        var attributes: [UICollectionViewLayoutAttributes] = []
-        var beganIntercepting = false
-        var missCount = 0
-        for sectionIndex in startSectionIndex..<cellCache.count {
-            if let validSection = cellCache[sectionIndex], validSection.count > 0 {
-                // Add header view attributes
-                if thereAreHeaders {
-                    if headerCache[sectionIndex]!.frame.intersects(rect) { attributes.append(headerCache[sectionIndex]!) }
-                }
-                for val in validSection {
-                    if val.frame.intersects(rect) {
-                        missCount = 0
-                        beganIntercepting = true
-                        attributes.append(val)
-                    } else {
-                        missCount += 1
-                        // If there are at least 8 misses in a row since intercepting began, then this section has no more interceptions. So break
-                        if missCount > maxMissCount && beganIntercepting { break }
-                    }
-                }
-                if missCount > maxMissCount && beganIntercepting { break }// Also break from outter loop
-            }
-        }
-        return attributes
-    }
-    /// Returns the layout attributes for the item at the specified index path. A layout attributes object containing the information to apply to the item’s cell.
-    override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        // If this index is already cached, then return it else, apply a new layout attribut to it
-        if let alreadyCachedCellAttrib = cellCache[indexPath.section], indexPath.item < alreadyCachedCellAttrib.count, indexPath.item >= 0 {
-            return alreadyCachedCellAttrib[indexPath.item]
-        }
-        return deterimeToApplyAttribs(at: indexPath)
-    }
-    
-    func deterimeToApplyAttribs(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        let monthIndex = monthMap[indexPath.section]!
-        let numberOfDays = numberOfDaysInSection(monthIndex)
-        if !(0...maxSections ~= indexPath.section) || !(0...numberOfDays  ~= indexPath.item) { return nil} // return nil on invalid range
-        let attr = UICollectionViewLayoutAttributes(forCellWith: indexPath)
-        applyLayoutAttributes(attr)
-        return attr
-    }
-    /// Returns the layout attributes for the specified supplementary view.
-    open override func layoutAttributesForSupplementaryView(ofKind elementKind: String, at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
-        let attributes = UICollectionViewLayoutAttributes(forSupplementaryViewOfKind: elementKind, with: indexPath)
-        if let alreadyCachedHeaderAttrib = headerCache[indexPath.section] {
-            return alreadyCachedHeaderAttrib
-        }
-        
-        let headerSize = cachedHeaderSizeForSection(indexPath.section)
 
-        switch scrollDirection {
-        case .horizontal:
-            let modifiedSize = sizeForitemAtIndexPath(indexPath)
-            attributes.frame = CGRect(x: contentWidth, y: 0, width: modifiedSize.width * 7, height: headerSize.height)
-        case .vertical:
-            // Use the calculaed header size and force the width of the header to take up 7 columns
-            // We cache the header here so we dont call the delegate so much
-            
-            let modifiedSize = CGSize(width: collectionView!.frame.width, height: headerSize.height)
-            attributes.frame = CGRect(x: 0, y: yCellOffset, width: modifiedSize.width, height: modifiedSize.height)
-        }
-        if attributes.frame == CGRect.zero { return nil }
-        return attributes
+    /// Returns the layout attributes for all of the cells
+    /// and views in the specified rectangle.
+    override open func layoutAttributesForElements(in rect: CGRect) ->
+        [UICollectionViewLayoutAttributes]? {
+            let startSectionIndex = startIndexFrom(rectOrigin: rect.origin)
+            // keep looping until there were no interception rects
+            var attributes: [UICollectionViewLayoutAttributes] = []
+            var beganIntercepting = false
+            var missCount = 0
+            for sectionIndex in startSectionIndex..<cellCache.count {
+                if let validSection = cellCache[sectionIndex],
+                    validSection.count > 0 {
+                        // Add header view attributes
+                        if thereAreHeaders {
+                            if headerCache[sectionIndex]!
+                                .frame.intersects(rect) {
+                                    attributes
+                                        .append(headerCache[sectionIndex]!)
+                            }
+                        }
+                        for val in validSection {
+                            if val.frame.intersects(rect) {
+                                missCount = 0
+                                beganIntercepting = true
+                                attributes.append(val)
+                            } else {
+                                missCount += 1
+                                // If there are at least 8 misses in a row
+                                // since intercepting began, then this
+                                // section has no more interceptions.
+                                // So break
+                                if missCount > maxMissCount &&
+                                    beganIntercepting {
+                                    break
+                                }
+                            }
+                        }
+                        if missCount > maxMissCount && beganIntercepting {
+                            break
+                        }// Also break from outter loop
+                }
+            }
+            return attributes
     }
-    func applyLayoutAttributes(_ attributes: UICollectionViewLayoutAttributes) {
-        if attributes.representedElementKind != nil { return }
-        // Calculate the item size
-        let size = sizeForitemAtIndexPath(attributes.indexPath)
-        attributes.frame = CGRect(x: xCellOffset + stride, y: yCellOffset, width: size.width, height: size.height)
+
+    /// Returns the layout attributes for the item at the specified index
+    // path. A layout attributes object containing the information to apply
+    // to the item’s cell.
+    override open func layoutAttributesForItem(at indexPath: IndexPath) ->
+        UICollectionViewLayoutAttributes? {
+            // If this index is already cached, then return it else,
+            // apply a new layout attribut to it
+            if let alreadyCachedCellAttrib = cellCache[indexPath.section],
+                indexPath.item < alreadyCachedCellAttrib.count,
+                indexPath.item >= 0 {
+                    return alreadyCachedCellAttrib[indexPath.item]
+            }
+            return deterimeToApplyAttribs(at: indexPath)
     }
+
+    func deterimeToApplyAttribs(at indexPath: IndexPath) ->
+        UICollectionViewLayoutAttributes? {
+            let monthIndex = monthMap[indexPath.section]!
+            let numberOfDays = numberOfDaysInSection(monthIndex)
+            if !(0...maxSections ~= indexPath.section) ||
+                !(0...numberOfDays  ~= indexPath.item) {
+                    return nil
+            } // return nil on invalid range
+            let attr =
+                UICollectionViewLayoutAttributes(forCellWith: indexPath)
+            applyLayoutAttributes(attr)
+            return attr
+    }
+
+    /// Returns the layout attributes for the specified supplementary view.
+    open override func layoutAttributesForSupplementaryView(
+        ofKind elementKind: String, at indexPath: IndexPath) ->
+        UICollectionViewLayoutAttributes? {
+
+            let attributes = UICollectionViewLayoutAttributes(
+                forSupplementaryViewOfKind: elementKind, with: indexPath)
+            if let alreadyCachedHeaderAttrib =
+                headerCache[indexPath.section] {
+                    return alreadyCachedHeaderAttrib
+            }
+
+            let headerSize = cachedHeaderSizeForSection(indexPath.section)
+
+            switch scrollDirection {
+            case .horizontal:
+                let modifiedSize = sizeForitemAtIndexPath(indexPath)
+                attributes.frame = CGRect(x: contentWidth, y: 0,
+                                          width: modifiedSize.width * 7,
+                                          height: headerSize.height)
+            case .vertical:
+                // Use the calculaed header size and force the width
+                // of the header to take up 7 columns
+                // We cache the header here so we dont call the
+                // delegate so much
+
+                let modifiedSize = CGSize(width: collectionView!.frame.width,
+                                          height: headerSize.height)
+                attributes.frame = CGRect(x: 0, y: yCellOffset,
+                                          width: modifiedSize.width,
+                                          height: modifiedSize.height)
+            }
+            if attributes.frame == CGRect.zero {
+                return nil
+            }
+            return attributes
+    }
+
+    func applyLayoutAttributes(
+        _ attributes: UICollectionViewLayoutAttributes) {
+            if attributes.representedElementKind != nil {
+                return
+            }
+            // Calculate the item size
+            let size = sizeForitemAtIndexPath(attributes.indexPath)
+            attributes.frame = CGRect(
+                x: xCellOffset + stride,
+                y: yCellOffset,
+                width: size.width,
+                height: size.height
+        )
+    }
+
     func numberOfDaysInSection(_ index: Int) -> Int {
-        if let days = daysInSection[index] { return days }
+        if let days = daysInSection[index] {
+            return days
+        }
         let days = monthData[index].numberOfDaysInMonthGrid
         daysInSection[index] = days
         return days
     }
+
     func cachedHeaderSizeForSection(_ section: Int) -> CGSize {
         // We cache the header here so we dont call the delegate so much
         var headerSize = CGSize.zero
-        if let cachedHeader  = currentHeader, cachedHeader.section == section {
-            headerSize = cachedHeader.size
+        if let cachedHeader  = currentHeader,
+            cachedHeader.section == section {
+                headerSize = cachedHeader.size
         } else {
             headerSize = delegate!.referenceSizeForHeaderInSection(section)
             currentHeader = (section, headerSize)
         }
         return headerSize
     }
+
     func sizeForitemAtIndexPath(_ indexPath: IndexPath) -> CGSize {
         // Return the size if the cell size is already cached
-        if let cachedCell  = currentCell, cachedCell.section == indexPath.section {
-            return cachedCell.itemSize
+        if let cachedCell  = currentCell,
+            cachedCell.section == indexPath.section {
+                return cachedCell.itemSize
         }
-        
+
         var size: CGSize = CGSize.zero
         if let _ = delegate!.itemSize {
             if scrollDirection == .vertical {
@@ -281,11 +401,15 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
                 size.width = itemSize.width
                 var headerSize =  CGSize.zero
                 if thereAreHeaders {
-                    headerSize = cachedHeaderSizeForSection(indexPath.section)
+                    headerSize =
+                        cachedHeaderSizeForSection(indexPath.section)
                 }
-                
+
                 let currentMonth = monthData[monthMap[indexPath.section]!]
-                size.height = (collectionView!.frame.height - headerSize.height) / CGFloat(currentMonth.maxNumberOfRowsForFull(developerSetRows: numberOfRows))
+                size.height =
+                    (collectionView!.frame.height - headerSize.height) /
+                    CGFloat(currentMonth.maxNumberOfRowsForFull(
+                        developerSetRows: numberOfRows))
                 currentCell = (section: indexPath.section, itemSize: size)
             }
         } else {
@@ -296,57 +420,75 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
             }
             var height: CGFloat = 0
 
-            let totalNumberOfRows = monthData[monthMap[indexPath.section]!].rows
+            let totalNumberOfRows =
+                monthData[monthMap[indexPath.section]!].rows
             let currentMonth = monthData[monthMap[indexPath.section]!]
-            let monthSection = currentMonth.sectionIndexMaps[indexPath.section]!
-            let numberOfSections = CGFloat(totalNumberOfRows) / CGFloat(numberOfRows)
+            let monthSection = currentMonth
+                .sectionIndexMaps[indexPath.section]!
+            let numberOfSections =
+                CGFloat(totalNumberOfRows) / CGFloat(numberOfRows)
             let fullSections =  Int(numberOfSections)
             let numberOfRowsForSection: Int
             if scrollDirection == .horizontal {
-                numberOfRowsForSection = currentMonth.maxNumberOfRowsForFull(developerSetRows: numberOfRows)
-                height = (collectionView!.frame.height - headerSize.height) / CGFloat(numberOfRowsForSection)
+                numberOfRowsForSection = currentMonth
+                    .maxNumberOfRowsForFull(developerSetRows: numberOfRows)
+                height = (collectionView!.frame.height - headerSize.height) /
+                    CGFloat(numberOfRowsForSection)
             } else {
                 if monthSection + 1 <= fullSections {
                     numberOfRowsForSection = numberOfRows
                 } else {
-                    numberOfRowsForSection = totalNumberOfRows - (monthSection * numberOfRows)
+                    numberOfRowsForSection = totalNumberOfRows -
+                        (monthSection * numberOfRows)
                 }
-                height = (collectionView!.frame.height - headerSize.height) / CGFloat(numberOfRowsForSection)
+                height = (collectionView!.frame.height - headerSize.height) /
+                    CGFloat(numberOfRowsForSection)
             }
             size        = CGSize(width: itemSize.width, height: height)
             currentCell = (section: indexPath.section, itemSize: size)
-            
+
         }
         return size
     }
+
     func sizeOfSection(_ section: Int) -> CGFloat {
         switch scrollDirection {
         case .horizontal:
-            return cellCache[section]![0].frame.width * CGFloat(maxNumberOfDaysInWeek)
+            return cellCache[section]![0].frame.width *
+                CGFloat(maxNumberOfDaysInWeek)
         case .vertical:
-            let headerSizeOfSection = headerCache.count > 0 ? headerCache[section]!.frame.height : 0
-            return cellCache[section]![0].frame.height * CGFloat(numberOfRowsForMonth(section)) + headerSizeOfSection
+            let headerSizeOfSection = headerCache.count > 0 ?
+                headerCache[section]!.frame.height : 0
+            return cellCache[section]![0].frame.height *
+                CGFloat(numberOfRowsForMonth(section)) + headerSizeOfSection
         }
     }
+
     func numberOfRowsForMonth(_ index: Int) -> Int {
         let monthIndex = monthMap[index]!
         return monthData[monthIndex].rows
     }
+
     func startIndexFrom(rectOrigin offset: CGPoint) -> Int {
         let key =  scrollDirection == .horizontal ? offset.x : offset.y
         return startIndexBinarySearch(sectionSize, offset: key)
     }
+
     func sizeOfContentForSection(_ section: Int) -> CGFloat {
         return sizeOfSection(section)
     }
+
     func sectionFromRectOffset(_ offset: CGPoint) -> Int {
         let theOffet = scrollDirection == .horizontal ? offset.x : offset.y
         return sectionFromOffset(theOffet)
     }
+
     func sectionFromOffset(_ theOffSet: CGFloat) -> Int {
         var val: Int = 0
         for (index, sectionSizeValue) in sectionSize.enumerated() {
-            if abs(theOffSet - sectionSizeValue) < errorDelta { continue }
+            if abs(theOffSet - sectionSizeValue) < errorDelta {
+                continue
+            }
             if theOffSet < sectionSizeValue {
                 val = index
                 break
@@ -354,15 +496,19 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
         }
         return val
     }
+
     func startIndexBinarySearch<T: Comparable>(_ val: [T], offset: T) -> Int {
-        if val.count < 3 { return 0} // If the range is less than 2 just break here.
+        if val.count < 3 {
+            return 0
+        } // If the range is less than 2 just break here.
         var midIndex: Int = 0
         var startIndex = 0
         var endIndex = val.count - 1
         while startIndex < endIndex {
             midIndex = startIndex + (endIndex - startIndex) / 2
-            if midIndex + 1  >= val.count || offset >= val[midIndex] && offset < val[midIndex + 1] ||  val[midIndex] == offset {
-                break
+            if midIndex + 1  >= val.count || offset >= val[midIndex] &&
+                offset < val[midIndex + 1] ||  val[midIndex] == offset {
+                    break
             } else if val[midIndex] < offset {
                 startIndex = midIndex + 1
             } else {
@@ -371,16 +517,23 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
         }
         return midIndex
     }
-    /// Returns an object initialized from data in a given unarchiver. self, initialized using the data in decoder.
+
+    /// Returns an object initialized from data in a given unarchiver.
+    /// self, initialized using the data in decoder.
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    /// Returns the content offset to use after an animation layout update or change.
-    /// - Parameter proposedContentOffset: The proposed point for the upper-left corner of the visible content
+
+    /// Returns the content offset to use after an animation
+    /// layout update or change.
+    /// - Parameter proposedContentOffset: The proposed point for the
+    ///   upper-left corner of the visible content
     /// - returns: The content offset that you want to use instead
-    open override func targetContentOffset(forProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
-        return proposedContentOffset
+    open override func targetContentOffset(
+        forProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {
+            return proposedContentOffset
     }
+
     func clearCache() {
         headerCache.removeAll()
         cellCache.removeAll()
@@ -394,4 +547,5 @@ open class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutP
         contentWidth = 0
         stride = 0
     }
+
 }

--- a/Sources/JTAppleCalendarLayoutProtocol.swift
+++ b/Sources/JTAppleCalendarLayoutProtocol.swift
@@ -11,15 +11,14 @@ protocol JTAppleCalendarLayoutProtocol: class {
     var itemSize: CGSize {get set}
     var headerReferenceSize: CGSize {get set}
     var scrollDirection: UICollectionViewScrollDirection {get set}
-    var cellCache: [Int:[UICollectionViewLayoutAttributes]] {get set}
+    var cellCache: [Int: [UICollectionViewLayoutAttributes]] {get set}
     var headerCache: [Int: UICollectionViewLayoutAttributes] {get set}
     var sectionSize: [CGFloat] {get set}
-    func targetContentOffsetForProposedContentOffset(_ proposedContentOffset: CGPoint) -> CGPoint
+    func targetContentOffsetForProposedContentOffset(
+        _ proposedContentOffset: CGPoint) -> CGPoint
     func sectionFromRectOffset(_ offset: CGPoint) -> Int
     func sectionFromOffset(_ theOffSet: CGFloat) -> Int
     func sizeOfContentForSection(_ section: Int) -> CGFloat
     func clearCache()
     func prepare()
 }
-
-

--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -9,17 +9,21 @@
 let cellReuseIdentifier = "JTDayCell"
 
 
-let maxNumberOfDaysInWeek = 7                              // Should not be changed
-let maxNumberOfRowsPerMonth = 6                            // Should not be changed
-let developerErrorMessage = "There was an error in this code section. Please contact the developer on GitHub"
+let maxNumberOfDaysInWeek = 7 // Should not be changed
+let maxNumberOfRowsPerMonth = 6 // Should not be changed
+let developerErrorMessage = "There was an error in this code section. " +
+    "Please contact the developer on GitHub"
 
-/// An instance of JTAppleCalendarView (or simply, a calendar view) is a means for displaying and interacting with a gridstyle layout of date-cells
+/// An instance of JTAppleCalendarView (or simply, a calendar view) is a
+/// means for displaying and interacting with a gridstyle layout of date-cells
 open class JTAppleCalendarView: UIView {
+
     lazy var dateGenerator: JTAppleDateConfigGenerator = {
         var configurator = JTAppleDateConfigGenerator()
         configurator.delegate = self
         return configurator
     }()
+
     /// Configures the behavior of the scrolling mode of the calendar
     public enum ScrollingMode {
         case stopAtEachCalendarFrameWidth,
@@ -29,14 +33,16 @@ open class JTAppleCalendarView: UIView {
         nonStopToCell(withResistance: CGFloat),
         nonStopTo(customInterval: CGFloat, withResistance: CGFloat),
         none
+
         func  pagingIsEnabled() -> Bool {
             switch self {
             case .stopAtEachCalendarFrameWidth: return true
             default: return false
             }
         }
+
     }
-    
+
     var calendarIsAlreadyLoaded: Bool {
         get {
             if let alreadyLoaded = finalLoadable, alreadyLoaded {
@@ -45,6 +51,7 @@ open class JTAppleCalendarView: UIView {
             return false
         }
     }
+
     /// Configures the size of your date cells
     open var itemSize: CGFloat? {
         didSet {
@@ -53,45 +60,59 @@ open class JTAppleCalendarView: UIView {
             layoutNeedsUpdating = true
         }
     }
+
     /// Enables and disables animations when scrolling to and from date-cells
     open var animationsEnabled = true
+
     /// The scroll direction of the sections in JTAppleCalendar.
     open var direction: UICollectionViewScrollDirection = .horizontal {
         didSet {
-            if oldValue == direction { return }
+            if oldValue == direction {
+                return
+            }
             calendarViewLayout.scrollDirection = direction
             updateLayoutItemSize()
             layoutNeedsUpdating = true
         }
     }
+
     /// Enables/Disables multiple selection on JTAppleCalendar
     open var allowsMultipleSelection: Bool = false {
         didSet {
-            self.calendarView.allowsMultipleSelection = allowsMultipleSelection
+            self.calendarView.allowsMultipleSelection =
+            allowsMultipleSelection
         }
     }
 
-    /// Alerts the calendar that range selection will be checked. If you are not using rangeSelection and you enable this,
-    /// then whenever you click on a datecell, you may notice a very fast refreshing of the date-cells both left and right of the cell you just selected.
+    /// Alerts the calendar that range selection will be checked. If you are
+    /// not using rangeSelection and you enable this,
+    /// then whenever you click on a datecell, you may notice a very fast
+    /// refreshing of the date-cells both left and right of the cell you
+    /// just selected.
     open var rangeSelectionWillBeUsed = false
     var lastSavedContentOffset: CGFloat = 0.0
     var triggerScrollToDateDelegate: Bool? = true
     // Keeps track of item size for a section. This is an optimization
     var scrollInProgress = false
+
     var calendarViewLayout: JTAppleCalendarLayout {
         get {
-            guard let layout = calendarView.collectionViewLayout as? JTAppleCalendarLayout else {
-                developerError(string: "Calendar layout is not of type `JTAppleCalendarLayout`.")
-                return JTAppleCalendarLayout(withDelegate: self)
+            guard let layout = calendarView.collectionViewLayout as?
+                JTAppleCalendarLayout else {
+                    developerError(string: "Calendar layout is not of type " +
+                        "`JTAppleCalendarLayout`.")
+                    return JTAppleCalendarLayout(withDelegate: self)
             }
             return layout
         }
     }
+
     var layoutNeedsUpdating = false {
         didSet {
             print("")
         }
     }
+
     /// The object that acts as the data source of the calendar view.
     weak open var dataSource: JTAppleCalendarViewDataSource? {
         didSet {
@@ -99,54 +120,82 @@ open class JTAppleCalendarView: UIView {
             setupMonthInfoAndMap()
         }
     }
+
     func setupMonthInfoAndMap() {
         theData = setupMonthInfoDataForStartAndEndDate()
     }
+
     /// Lays out subviews.
-    override open func layoutSubviews() { self.frame = super.frame }
-    /// The frame rectangle which defines the view's location and size in its superview coordinate system.
+    override open func layoutSubviews() {
+        self.frame = super.frame
+    }
+
+    /// The frame rectangle which defines the view's location and size in
+    /// its superview coordinate system.
     override open var frame: CGRect {
         didSet {
-            calendarView.frame = CGRect(x: 0, y:0, width: self.frame.width, height: self.frame.height)
+            calendarView.frame = CGRect(x: 0, y: 0, width: self.frame.width,
+                                        height: self.frame.height)
             updateLayoutItemSize()
             if calendarViewLayout.itemSize != lastSize {
                 lastSize = calendarViewLayout.itemSize
                 if delegate != nil {
-                    var anInitialCompletionHandler: (()->Void)?
+                    var anInitialCompletionHandler: (() -> Void)?
                     if finalLoadable == nil { // This will only be set once
                         finalLoadable = true
-                        anInitialCompletionHandler = { self.executeDelayedTasks() }
+                        anInitialCompletionHandler = {
+                            self.executeDelayedTasks()
+                        }
                     }
                     reloadData(completionHandler: anInitialCompletionHandler)
                 }
             }
         }
     }
-    
+
     /// The object that acts as the delegate of the calendar view.
     weak open var delegate: JTAppleCalendarViewDelegate?
 
     var delayedExecutionClosure: [(() -> Void)] = []
     var lastSize = CGSize.zero
     var finalLoadable: Bool?
+
     var currentSectionPage: Int {
-        return calendarViewLayout.sectionFromRectOffset(calendarView.contentOffset)
+        return calendarViewLayout
+            .sectionFromRectOffset(calendarView.contentOffset)
     }
 
     var startDateCache: Date {
-        get { return cachedConfiguration.startDate }
+        get {
+            return cachedConfiguration.startDate
+        }
     }
+
     var endDateCache: Date {
-        get { return cachedConfiguration.endDate }
+        get {
+            return cachedConfiguration.endDate
+        }
     }
+
     var calendar: Calendar {
-        get { return cachedConfiguration.calendar }
+        get {
+            return cachedConfiguration.calendar
+        }
     }
+
     lazy var cachedConfiguration: ConfigurationParameters = {
         [weak self] in
         guard let  config = self!.dataSource?.configureCalendar(self!) else {
             assert(false, "DataSource is not set")
-            return ConfigurationParameters(startDate: Date(), endDate: Date(), numberOfRows: 0, calendar: Calendar(identifier: .gregorian), generateInDates: false, generateOutDates: .off, firstDayOfWeek: .sunday)
+            return ConfigurationParameters(
+                startDate: Date(),
+                endDate: Date(),
+                numberOfRows: 0,
+                calendar: Calendar(identifier: .gregorian),
+                generateInDates: false,
+                generateOutDates: .off,
+                firstDayOfWeek: .sunday
+            )
         }
         return ConfigurationParameters(startDate: config.startDate,
                 endDate: config.endDate,
@@ -154,69 +203,111 @@ open class JTAppleCalendarView: UIView {
                 calendar: config.calendar,
                 generateInDates: config.generateInDates,
                 generateOutDates: config.generateOutDates,
-                firstDayOfWeek: config.firstDayOfWeek)
-        }()
+                firstDayOfWeek: config.firstDayOfWeek
+        )
+    }()
+
     // Set the start of the month
     lazy var startOfMonthCache: Date = {
         [weak self] in
-        if let startDate = Date.startOfMonth(for: self!.startDateCache, using: self!.calendar) { return startDate }
-        assert(false, "Error: StartDate was not correctly generated for start of month. current date was used: \(Date())")
+        if let startDate = Date.startOfMonth(for: self!.startDateCache,
+                                             using: self!.calendar) {
+            return startDate
+        }
+        assert(false, "Error: StartDate was not correctly generated for " +
+            "start of month. current date was used: \(Date())")
         return Date()
         }()
+
     // Set the end of month
     lazy var endOfMonthCache: Date = {
         [weak self] in
-        if let endDate = Date.endOfMonth(for: self!.endDateCache, using: self!.calendar) { return endDate }
-        assert(false, "Error: Date was not correctly generated for end of month. current date was used: \(Date())")
+        if let endDate = Date.endOfMonth(for: self!.endDateCache,
+                                         using: self!.calendar) {
+            return endDate
+        }
+        assert(false, "Error: Date was not correctly generated for end " +
+            "of month. current date was used: \(Date())")
         return Date()
         }()
+
     var theSelectedIndexPaths: [IndexPath] = []
-    var theSelectedDates: [Date]           = []
+    var theSelectedDates: [Date] = []
+
     /// Returns all selected dates
     open var selectedDates: [Date] {
         get {
-            // Array may contain duplicate dates in case where out-dates are selected. So clean it up here
+            // Array may contain duplicate dates in case where out-dates
+            // are selected. So clean it up here
             return Array(Set(theSelectedDates)).sorted()
         }
     }
+
     lazy var theData: CalendarData = {
         [weak self] in
         return self!.setupMonthInfoDataForStartAndEndDate()
     }()
+
     var monthInfo: [Month] {
-        get { return theData.months }
-        set { theData.months = monthInfo}
+        get {
+            return theData.months
+        }
+        set {
+            theData.months = monthInfo
+        }
     }
-    var monthMap: [Int:Int] {
-        get { return theData.monthMap }
-        set { theData.monthMap = monthMap }
+
+    var monthMap: [Int: Int] {
+        get {
+            return theData.monthMap
+        }
+        set {
+            theData.monthMap = monthMap
+        }
     }
+
     var numberOfMonths: Int {
-        get { return monthInfo.count }
+        get {
+            return monthInfo.count
+        }
     }
+
     var totalDays: Int {
-        get { return theData.totalDays }
+        get {
+            return theData.totalDays
+        }
     }
-    func numberOfItemsInSection(_ section: Int) -> Int {return collectionView(calendarView, numberOfItemsInSection: section)}
-    /// Cell inset padding for the x and y axis of every date-cell on the calendar view.
+
+    func numberOfItemsInSection(_ section: Int) -> Int {
+        return collectionView(calendarView, numberOfItemsInSection: section)
+    }
+
+    /// Cell inset padding for the x and y axis
+    /// of every date-cell on the calendar view.
     open var cellInset: CGPoint = CGPoint(x: 3, y: 3)
     var cellViewSource: JTAppleCalendarViewSource!
     var registeredHeaderViews: [JTAppleCalendarViewSource] = []
 
     /// Enable or disable swipe scrolling of the calendar with this variable
     open var scrollEnabled: Bool = true {
-        didSet { calendarView.isScrollEnabled = scrollEnabled }
+        didSet {
+            calendarView.isScrollEnabled = scrollEnabled
+        }
     }
+
     // Configure the scrolling behavior
     open var scrollingMode: ScrollingMode = .stopAtEachCalendarFrameWidth {
         didSet {
             switch scrollingMode {
             case .stopAtEachCalendarFrameWidth:
-                calendarView.decelerationRate = UIScrollViewDecelerationRateFast
+                calendarView.decelerationRate =
+                UIScrollViewDecelerationRateFast
             case .stopAtEach, .stopAtEachSection:
-                calendarView.decelerationRate = UIScrollViewDecelerationRateFast
+                calendarView.decelerationRate =
+                UIScrollViewDecelerationRateFast
             case .nonStopToSection, .nonStopToCell, .nonStopTo, .none:
-                calendarView.decelerationRate = UIScrollViewDecelerationRateNormal
+                calendarView.decelerationRate =
+                UIScrollViewDecelerationRateNormal
             }
             #if os(iOS)
                 switch scrollingMode {
@@ -228,10 +319,12 @@ open class JTAppleCalendarView: UIView {
             #endif
         }
     }
+
     lazy var calendarView: UICollectionView = {
         let layout = JTAppleCalendarLayout(withDelegate: self)
         layout.scrollDirection = self.direction
-        let cv = UICollectionView(frame: CGRect.zero, collectionViewLayout: layout)
+        let cv = UICollectionView(frame: CGRect.zero,
+                                  collectionViewLayout: layout)
         cv.dataSource = self
         cv.delegate = self
         cv.decelerationRate = UIScrollViewDecelerationRateFast
@@ -244,22 +337,33 @@ open class JTAppleCalendarView: UIView {
         #endif
         return cv
     }()
-    fileprivate func updateLayoutItemSize () {
-        if dataSource == nil { return } // If the delegate is not set yet, then return, becaus edelegate methods will be called on the layout
+
+    fileprivate func updateLayoutItemSize() {
+        if dataSource == nil {
+            return
+        } // If the delegate is not set yet, then return, becaus
+          // edelegate methods will be called on the layout
         let layout = calendarViewLayout
-        
+
         // Invalidate the layout
-        
+
         // Default Item height
-        var height: CGFloat = (self.calendarView.bounds.size.height - layout.headerReferenceSize.height) / CGFloat(cachedConfiguration.numberOfRows)
+        var height: CGFloat = (self.calendarView.bounds.size.height -
+            layout.headerReferenceSize.height) /
+            CGFloat(cachedConfiguration.numberOfRows)
         // Default Item width
-        var width: CGFloat = self.calendarView.bounds.size.width / CGFloat(maxNumberOfDaysInWeek)
+        var width: CGFloat = self.calendarView.bounds.size.width /
+            CGFloat(maxNumberOfDaysInWeek)
 
         if let userSetItemSize = self.itemSize {
-            if direction == .vertical { height = userSetItemSize } else { width = userSetItemSize }
+            if direction == .vertical {
+                height = userSetItemSize
+            } else {
+                width = userSetItemSize
+            }
         }
         let size = CGSize(width: width, height: height)
-        
+
         if lastSize != size {
             layout.invalidateLayout()
             layout.clearCache()
@@ -267,129 +371,197 @@ open class JTAppleCalendarView: UIView {
             layout.itemSize = size
         }
     }
-    /// Initializes and returns a newly allocated view object with the specified frame rectangle.
+
+    /// Initializes and returns a newly allocated
+    /// view object with the specified frame rectangle.
     public override init(frame: CGRect) {
         super.init(frame: frame)
         self.initialSetup()
     }
+
     func developerError(string: String) {
         print(string)
         print(developerErrorMessage)
         assert(false)
     }
-    /// Returns an object initialized from data in a given unarchiver. self, initialized using the data in decoder.
-    required public init?(coder aDecoder: NSCoder) { super.init(coder: aDecoder) }
-    /// Prepares the receiver for service after it has been loaded from an Interface Builder archive, or nib file.
-    override open func awakeFromNib() { self.initialSetup() }
+
+    /// Returns an object initialized from data in a given unarchiver.
+    /// self, initialized using the data in decoder.
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    /// Prepares the receiver for service after it has been loaded
+    /// from an Interface Builder archive, or nib file.
+    override open func awakeFromNib() {
+        self.initialSetup()
+    }
+
     // MARK: Setup
     func initialSetup() {
         self.clipsToBounds = true
-        self.calendarView.register(JTAppleDayCell.self, forCellWithReuseIdentifier: cellReuseIdentifier)
+        self.calendarView.register(JTAppleDayCell.self,
+                        forCellWithReuseIdentifier: cellReuseIdentifier)
         self.addSubview(self.calendarView)
     }
+
     func restoreSelectionStateForCellAtIndexPath(_ indexPath: IndexPath) {
         if theSelectedIndexPaths.contains(indexPath) {
-            calendarView.selectItem(at: indexPath, animated: false, scrollPosition: UICollectionViewScrollPosition())
+            calendarView.selectItem(
+                at: indexPath,
+                animated: false,
+                scrollPosition: UICollectionViewScrollPosition()
+            )
         }
     }
-    func validForwardAndBackwordSelectedIndexes(forIndexPath indexPath: IndexPath) -> [IndexPath] {
+
+    func validForwardAndBackwordSelectedIndexes(
+                    forIndexPath indexPath: IndexPath) -> [IndexPath] {
         var retval = [IndexPath]()
-        if let validForwardIndex = calendarView.layoutAttributesForItem(at: IndexPath(item: indexPath.item + 1, section: indexPath.section)) ,
+        if let validForwardIndex = calendarView
+            .layoutAttributesForItem(
+                at: IndexPath(item: indexPath.item + 1,
+                              section: indexPath.section)),
             theSelectedIndexPaths.contains(validForwardIndex.indexPath) {
-            retval.append(validForwardIndex.indexPath)
+                retval.append(validForwardIndex.indexPath)
         }
-        if let validBackwardIndex = calendarView.collectionViewLayout.layoutAttributesForItem(at: IndexPath(item: indexPath.item - 1, section: indexPath.section)) ,
+        if let validBackwardIndex = calendarView
+            .collectionViewLayout.layoutAttributesForItem(
+                at: IndexPath(item: indexPath.item - 1,
+                              section: indexPath.section)),
             theSelectedIndexPaths.contains(validBackwardIndex.indexPath) {
-            retval.append(validBackwardIndex.indexPath)
+                retval.append(validBackwardIndex.indexPath)
         }
         return retval
     }
-    func calendarOffsetIsAlreadyAtScrollPosition(forIndexPath indexPath: IndexPath) -> Bool? {
-        var retval: Bool?
-        // If the scroll is set to animate, and the target content offset is already on the screen, then the didFinishScrollingAnimation
-        // delegate will not get called. Once animation is on let's force a scroll so the delegate MUST get caalled
-        if let attributes = self.calendarView.layoutAttributesForItem(at: indexPath) {
-            let layoutOffset: CGFloat
-            let calendarOffset: CGFloat
-            if direction == .horizontal {
-                layoutOffset = attributes.frame.origin.x
-                calendarOffset = calendarView.contentOffset.x
-            } else {
-                layoutOffset = attributes.frame.origin.y
-                calendarOffset = calendarView.contentOffset.y
+
+    func calendarOffsetIsAlreadyAtScrollPosition(
+        forIndexPath indexPath: IndexPath) -> Bool? {
+            var retval: Bool?
+            // If the scroll is set to animate, and the target content offset
+            // is already on the screen, then the didFinishScrollingAnimation
+            // delegate will not get called. Once animation is on let's force
+            // a scroll so the delegate MUST get caalled
+            if let attributes = self.calendarView
+                .layoutAttributesForItem(at: indexPath) {
+                let layoutOffset: CGFloat
+                let calendarOffset: CGFloat
+                if direction == .horizontal {
+                    layoutOffset = attributes.frame.origin.x
+                    calendarOffset = calendarView.contentOffset.x
+                } else {
+                    layoutOffset = attributes.frame.origin.y
+                    calendarOffset = calendarView.contentOffset.y
+                }
+                if  calendarOffset == layoutOffset ||
+                    (scrollingMode.pagingIsEnabled() &&
+                        (indexPath.section ==  currentSectionPage)) {
+                            retval = true
+                } else {
+                    retval = false
+                }
             }
-            if  calendarOffset == layoutOffset || (scrollingMode.pagingIsEnabled() && (indexPath.section ==  currentSectionPage)) {
+            return retval
+    }
+
+    func calendarOffsetIsAlreadyAtScrollPosition(
+        forOffset offset: CGPoint) -> Bool? {
+            var retval: Bool?
+            // If the scroll is set to animate, and the target content
+            // offset is already on the screen, then the
+            // didFinishScrollingAnimation
+            // delegate will not get called. Once animation is on let's
+            // force a scroll so the delegate MUST get caalled
+            let theOffset = direction == .horizontal ? offset.x : offset.y
+            let divValue = direction == .horizontal ?
+                calendarView.frame.width : calendarView.frame.height
+            let sectionForOffset = Int(theOffset / divValue)
+            let calendarCurrentOffset = direction == .horizontal ?
+                calendarView.contentOffset.x : calendarView.contentOffset.y
+            if calendarCurrentOffset == theOffset ||
+                    (scrollingMode.pagingIsEnabled() &&
+                    (sectionForOffset ==  currentSectionPage)) {
                 retval = true
             } else {
                 retval = false
             }
-        }
-        return retval
+            return retval
     }
-    func calendarOffsetIsAlreadyAtScrollPosition(forOffset offset: CGPoint) -> Bool? {
-        var retval: Bool?
-        // If the scroll is set to animate, and the target content offset is already on the screen, then the didFinishScrollingAnimation
-        // delegate will not get called. Once animation is on let's force a scroll so the delegate MUST get caalled
-        let theOffset = direction == .horizontal ? offset.x : offset.y
-        let divValue = direction == .horizontal ? calendarView.frame.width : calendarView.frame.height
-        let sectionForOffset = Int(theOffset / divValue)
-        let calendarCurrentOffset = direction == .horizontal ? calendarView.contentOffset.x : calendarView.contentOffset.y
-        if
-            calendarCurrentOffset == theOffset ||
-                (scrollingMode.pagingIsEnabled() && (sectionForOffset ==  currentSectionPage)) {
-            retval = true
-        } else {
-            retval = false
-        }
-        return retval
-    }
+
     func firstDayIndexForMonth(_ date: Date) -> Int {
         let firstDayCalValue: Int
         switch cachedConfiguration.firstDayOfWeek {
-        case .monday: firstDayCalValue = 6 case .tuesday: firstDayCalValue = 5 case .wednesday: firstDayCalValue = 4
-        case .thursday: firstDayCalValue = 10 case .friday: firstDayCalValue = 9
-        case .saturday: firstDayCalValue = 8 default: firstDayCalValue = 7
+        case .monday: firstDayCalValue = 6
+        case .tuesday: firstDayCalValue = 5
+        case .wednesday: firstDayCalValue = 4
+        case .thursday: firstDayCalValue = 10
+        case .friday: firstDayCalValue = 9
+        case .saturday: firstDayCalValue = 8
+        default: firstDayCalValue = 7
         }
-        var firstWeekdayOfMonthIndex = calendar.component(.weekday, from: date)
-        firstWeekdayOfMonthIndex -= 1 // firstWeekdayOfMonthIndex should be 0-Indexed
-        // push it modularly so that we take it back one day so that the first day is Monday instead of Sunday which is the default
+        var firstWeekdayOfMonthIndex =
+            calendar.component(.weekday, from: date)
+        firstWeekdayOfMonthIndex -= 1
+        // firstWeekdayOfMonthIndex should be 0-Indexed
+        // push it modularly so that we take it back one day so that the
+        // first day is Monday instead of Sunday which is the default
         return (firstWeekdayOfMonthIndex + firstDayCalValue) % 7
     }
+
     func scrollToHeaderInSection(_ section: Int,
                                  triggerScrollToDateDelegate: Bool = false,
                                  withAnimation animation: Bool = true,
                                  completionHandler: (() -> Void)? = nil) {
-        if registeredHeaderViews.count < 1 { return }
+        if registeredHeaderViews.count < 1 {
+            return
+        }
         self.triggerScrollToDateDelegate = triggerScrollToDateDelegate
         let indexPath = IndexPath(item: 0, section: section)
         delayRunOnMainThread(0.0) {
-            if let attributes =  self.calendarView.layoutAttributesForSupplementaryElement(ofKind: UICollectionElementKindSectionHeader, at: indexPath) {
+            if let attributes = self.calendarView
+                    .layoutAttributesForSupplementaryElement(
+                        ofKind: UICollectionElementKindSectionHeader,
+                        at: indexPath) {
+
                 if let validHandler = completionHandler {
                     self.delayedExecutionClosure.append(validHandler)
                 }
-                let topOfHeader = CGPoint(x: attributes.frame.origin.x, y: attributes.frame.origin.y)
+                let topOfHeader = CGPoint(x: attributes.frame.origin.x,
+                                          y: attributes.frame.origin.y)
                 self.scrollInProgress = true
-                self.calendarView.setContentOffset(topOfHeader, animated:animation)
+                self.calendarView.setContentOffset(topOfHeader,
+                                                   animated: animation)
                 if  !animation {
                     self.scrollViewDidEndScrollingAnimation(self.calendarView)
                     self.scrollInProgress = false
                 } else {
-                    // If the scroll is set to animate, and the target content offset is already on the screen, then the didFinishScrollingAnimation
-                    // delegate will not get called. Once animation is on let's force a scroll so the delegate MUST get caalled
-                    if let check = self.calendarOffsetIsAlreadyAtScrollPosition(forOffset: topOfHeader), check == true {
-                        self.scrollViewDidEndScrollingAnimation(self.calendarView)
+                    // If the scroll is set to animate, and the target
+                    // content offset is already on the screen, then the
+                    // didFinishScrollingAnimation
+                    // delegate will not get called. Once animation is on
+                    // let's force a scroll so the delegate MUST get caalled
+                    if let check = self
+                            .calendarOffsetIsAlreadyAtScrollPosition(
+                                forOffset: topOfHeader), check == true {
+
+                        self.scrollViewDidEndScrollingAnimation(
+                                                        self.calendarView)
                         self.scrollInProgress = false
                     }
                 }
             }
         }
     }
+
     func reloadData(checkDelegateDataSource check: Bool,
                     withAnchorDate anchorDate: Date? = nil,
                     withAnimation animation: Bool = false,
-                    completionHandler:(() -> Void)? = nil) {
+                    completionHandler: (() -> Void)? = nil) {
+
         // Reload the datasource
-        if check { reloadDelegateDataSource() }
+        if check {
+            reloadDelegateDataSource()
+        }
         var layoutWasUpdated: Bool?
         if layoutNeedsUpdating {
             self.configureChangeOfRows()
@@ -399,35 +571,55 @@ open class JTAppleCalendarView: UIView {
         // Reload the data
         self.calendarView.reloadData()
         // Restore the selected index paths
-        for indexPath in theSelectedIndexPaths { restoreSelectionStateForCellAtIndexPath(indexPath) }
+        for indexPath in theSelectedIndexPaths {
+            restoreSelectionStateForCellAtIndexPath(indexPath)
+        }
         delayRunOnMainThread(0.0) {
-            let scrollToDate = {(date: Date) -> Void in
+            let scrollToDate = { (date: Date) -> Void in
                 if self.registeredHeaderViews.count < 1 {
-                    self.scrollToDate(date, triggerScrollToDateDelegate: false, animateScroll: animation, completionHandler: completionHandler)
+                    self.scrollToDate(date,
+                                      triggerScrollToDateDelegate: false,
+                                      animateScroll: animation,
+                                      completionHandler: completionHandler)
                 } else {
-                    self.scrollToHeaderForDate(date, triggerScrollToDateDelegate: false, withAnimation: animation, completionHandler: completionHandler)
+                    self.scrollToHeaderForDate(
+                        date,
+                        triggerScrollToDateDelegate: false,
+                        withAnimation: animation,
+                        completionHandler: completionHandler
+                    )
                 }
             }
-            if let validAnchorDate = anchorDate { // If we have a valid anchor date, this means we want to scroll
+            if let validAnchorDate = anchorDate {
+                // If we have a valid anchor date, this means we want to
+                // scroll
                 // This scroll should happen after the reload above
                 scrollToDate(validAnchorDate)
             } else {
                 if layoutWasUpdated == true {
-                    // This is a scroll done after a layout reset and dev didnt set an anchor date. If a scroll is in progress, then cancel this one and
+                    // This is a scroll done after a layout reset and dev
+                    // didnt set an anchor date. If a scroll is in progress,
+                    // then cancel this one and
                     // allow it to take precedent
                     if !self.scrollInProgress {
                         if let validCompletionHandler = completionHandler {
                             validCompletionHandler()
                         }
-//                        self.calendarView.scrollToItem(at: IndexPath(item: 0, section:0), at: .left, animated: false)
+//                        self.calendarView.scrollToItem(
+//                        at: IndexPath(item: 0, section:0),
+//                        at: .left, animated: false)
 //                        scrollToDate(self.startOfMonthCache)
                     } else {
-                        if let validCompletionHandler = completionHandler { self.delayedExecutionClosure.append(validCompletionHandler) }
+                        if let validCompletionHandler = completionHandler {
+                            self.delayedExecutionClosure
+                                .append(validCompletionHandler)
+                        }
                     }
                 } else {
                     if let validCompletionHandler = completionHandler {
                         if self.scrollInProgress {
-                            self.delayedExecutionClosure.append(validCompletionHandler)
+                            self.delayedExecutionClosure
+                                .append(validCompletionHandler)
                         } else {
                             validCompletionHandler()
                         }
@@ -436,38 +628,57 @@ open class JTAppleCalendarView: UIView {
             }
         }
     }
+
     func executeDelayedTasks() {
         let tasksToExecute = delayedExecutionClosure
-        for aTaskToExecute in tasksToExecute { aTaskToExecute() }
+        for aTaskToExecute in tasksToExecute {
+            aTaskToExecute()
+        }
         delayedExecutionClosure.removeAll()
     }
+
     // Only reload the dates if the datasource information has changed
     fileprivate func reloadDelegateDataSource() {
         if let
             newDateBoundary = dataSource?.configureCalendar(self) {
-            // Jt101 do a check in each var to see if user has bad star/end dates
-            let newStartOfMonth = Date.startOfMonth(for: newDateBoundary.startDate, using: cachedConfiguration.calendar)
-            let newEndOfMonth = Date.endOfMonth(for: newDateBoundary.startDate, using: cachedConfiguration.calendar)
-            let oldStartOfMonth = Date.startOfMonth(for: cachedConfiguration.startDate, using: cachedConfiguration.calendar)
-            let oldEndOfMonth = Date.endOfMonth(for: cachedConfiguration.startDate, using: cachedConfiguration.calendar)
-            if
-                newStartOfMonth != oldStartOfMonth ||
+            // Jt101 do a check in each var to see if
+            // user has bad star/end dates
+            let newStartOfMonth =
+                Date.startOfMonth(for: newDateBoundary.startDate,
+                                  using: cachedConfiguration.calendar)
+            let newEndOfMonth =
+                Date.endOfMonth(for: newDateBoundary.startDate,
+                                using: cachedConfiguration.calendar)
+            let oldStartOfMonth =
+                Date.startOfMonth(for: cachedConfiguration.startDate,
+                                  using: cachedConfiguration.calendar)
+            let oldEndOfMonth =
+                Date.endOfMonth(for: cachedConfiguration.startDate,
+                                using: cachedConfiguration.calendar)
+            if newStartOfMonth != oldStartOfMonth ||
                 newEndOfMonth != oldEndOfMonth ||
                 newDateBoundary.calendar != cachedConfiguration.calendar ||
-                newDateBoundary.numberOfRows != cachedConfiguration.numberOfRows ||
-                newDateBoundary.generateInDates != cachedConfiguration.generateInDates ||
-                newDateBoundary.generateOutDates != cachedConfiguration.generateOutDates ||
-                newDateBoundary.firstDayOfWeek != cachedConfiguration.firstDayOfWeek {
-                    setupMonthInfoAndMap()
-                    layoutNeedsUpdating = true
+                newDateBoundary.numberOfRows !=
+                    cachedConfiguration.numberOfRows ||
+                newDateBoundary.generateInDates !=
+                    cachedConfiguration.generateInDates ||
+                newDateBoundary.generateOutDates !=
+                    cachedConfiguration.generateOutDates ||
+                newDateBoundary.firstDayOfWeek !=
+                    cachedConfiguration.firstDayOfWeek {
+
+                        setupMonthInfoAndMap()
+                        layoutNeedsUpdating = true
             }
         }
     }
+
     func configureChangeOfRows() {
         let layout = calendarViewLayout
         layout.clearCache()
         layout.prepare()
-        // the selected dates and paths will be retained. Ones that are not available on the new layout will be removed.
+        // the selected dates and paths will be retained. Ones that
+        // are not available on the new layout will be removed.
         var indexPathsToReselect = [IndexPath]()
         var newDates = [Date]()
         for date in selectedDates {
@@ -476,64 +687,99 @@ open class JTAppleCalendarView: UIView {
             indexPathsToReselect.append(contentsOf: path)
             if
                 path.count > 0,
-                let possibleCounterPartDateIndex = indexPathOfdateCellCounterPart(date, indexPath: path[0], dateOwner: DateOwner.thisMonth) {
+                let possibleCounterPartDateIndex =
+                indexPathOfdateCellCounterPart(date, indexPath: path[0],
+                                        dateOwner: DateOwner.thisMonth) {
                 indexPathsToReselect.append(possibleCounterPartDateIndex)
             }
         }
         for path in indexPathsToReselect {
-            if let date = dateInfoFromPath(path)?.date { newDates.append(date) }
+            if let date = dateInfoFromPath(path)?.date {
+                newDates.append(date)
+            }
         }
         theSelectedDates = newDates
         theSelectedIndexPaths = indexPathsToReselect
     }
+
     func calendarViewHeaderSizeForSection(_ section: Int) -> CGSize {
         var retval = CGSize.zero
         if registeredHeaderViews.count > 0 {
-            if let
-                validDate = monthInfoFromSection(section),
-                let size = delegate?.calendar(self, sectionHeaderSizeFor: validDate.range, belongingTo: validDate.month) {retval = size }
+            if let validDate = monthInfoFromSection(section),
+                let size = delegate?.calendar(self,
+                                    sectionHeaderSizeFor: validDate.range,
+                                    belongingTo: validDate.month) {
+                retval = size
+            }
         }
         return retval
     }
+
 }
 
 extension JTAppleCalendarView {
-    func indexPathOfdateCellCounterPart(_ date: Date, indexPath: IndexPath, dateOwner: DateOwner) -> IndexPath? {
-        if cachedConfiguration.generateInDates == false && cachedConfiguration.generateOutDates == .off { return nil }
+
+    func indexPathOfdateCellCounterPart(_ date: Date,
+                                        indexPath: IndexPath,
+                                        dateOwner: DateOwner) -> IndexPath? {
+        if cachedConfiguration.generateInDates == false &&
+            cachedConfiguration.generateOutDates == .off {
+            return nil
+        }
         var retval: IndexPath?
-        if dateOwner != .thisMonth { // If the cell is anything but this month, then the cell belongs to either a previous of following month
+        if dateOwner != .thisMonth {
+            // If the cell is anything but this month, then the cell belongs
+            // to either a previous of following month
             // Get the indexPath of the counterpartCell
             let counterPathIndex = pathsFromDates([date])
             if counterPathIndex.count > 0 {
                 retval = counterPathIndex[0]
             }
-        } else { // If the date does belong to this month, then lets find out if it has a counterpart date
-            if date < startOfMonthCache || date > endOfMonthCache { return retval }
-            guard let dayIndex = calendar.dateComponents([.day], from: date).day else {
+        } else {
+            // If the date does belong to this month,
+            // then lets find out if it has a counterpart date
+            if date < startOfMonthCache || date > endOfMonthCache {
+                return retval
+            }
+            guard let dayIndex = calendar
+                        .dateComponents([.day], from: date).day else {
                 print("Invalid Index")
                 return nil
             }
-            if case 1...13 = dayIndex { // then check the previous month
+            if case 1...13 = dayIndex {
+                // then check the previous month
                 // get the index path of the last day of the previous month
-                let periodApart = calendar.dateComponents([.month], from: startOfMonthCache, to: date)
-                guard let // If there is no previous months, there are no counterpart dates
-                    monthSectionIndex = periodApart.month,
+                let periodApart = calendar.dateComponents([.month],
+                                        from: startOfMonthCache, to: date)
+                guard let monthSectionIndex = periodApart.month,
                     monthSectionIndex - 1 >= 0 else {
+                        // If there is no previous months,
+                        // there are no counterpart dates
                         return retval
                 }
                 let previousMonthInfo = monthInfo[monthSectionIndex - 1]
-                // If there are no postdates for the previous month, then there are no counterpart dates
-                if previousMonthInfo.postDates < 1 || dayIndex > previousMonthInfo.postDates { return retval }
-                guard
-                    let prevMonth = calendar.date(byAdding: .month, value: -1, to: date),
-                    let lastDayOfPrevMonth = Date.endOfMonth(for: prevMonth, using: calendar) else {
-                        assert(false, "Error generating date in indexPathOfdateCellCounterPart(). Contact the developer on github")
-                        return retval
+                // If there are no postdates for the previous month,
+                // then there are no counterpart dates
+                if previousMonthInfo.postDates < 1 ||
+                    dayIndex > previousMonthInfo.postDates {
+                    return retval
                 }
-                
-                let indexPathOfLastDayOfPreviousMonth = pathsFromDates([lastDayOfPrevMonth])
+                guard let prevMonth = calendar
+                        .date(byAdding: .month, value: -1, to: date),
+                    let lastDayOfPrevMonth = Date
+                        .endOfMonth(for: prevMonth, using: calendar) else {
+                            assert(false, "Error generating date in " +
+                                "indexPathOfdateCellCounterPart(). " +
+                                "Contact the developer on github")
+                            return retval
+                }
+
+                let indexPathOfLastDayOfPreviousMonth =
+                    pathsFromDates([lastDayOfPrevMonth])
                 if indexPathOfLastDayOfPreviousMonth.count < 1 {
-                    print("out of range error in indexPathOfdateCellCounterPart() upper. This should not happen. Contact developer on github")
+                    print("out of range error in " +
+                        "indexPathOfdateCellCounterPart() upper. " +
+                        "This should not happen. Contact developer on github")
                     return retval
                 }
                 let lastDayIndexPath = indexPathOfLastDayOfPreviousMonth[0]
@@ -547,93 +793,135 @@ extension JTAppleCalendarView {
                 let reCalcRapth = IndexPath(item: itemIndex, section: section)
                 retval = reCalcRapth
             } else if case 26...31 = dayIndex { // check the following month
-                let periodApart = calendar.dateComponents([.month], from: startOfMonthCache, to: date)
+                let periodApart = calendar.dateComponents([.month],
+                                        from: startOfMonthCache, to: date)
                 let monthSectionIndex = periodApart.month!
-                if monthSectionIndex + 1 >= monthInfo.count { return retval }// If there is no following months, there are no counterpart dates
-                
+                if monthSectionIndex + 1 >= monthInfo.count {
+                    return retval
+                }// If there is no following months,
+                 // there are no counterpart dates
+
                 let followingMonthInfo = monthInfo[monthSectionIndex + 1]
-                if followingMonthInfo.preDates < 1 { return retval } // If there are no predates for the following month, then there are no counterpart dates
-                let lastDateOfCurrentMonth = Date.endOfMonth(for: date, using: calendar)!
-                let lastDay = calendar.component(.day, from: lastDateOfCurrentMonth)
+                if followingMonthInfo.preDates < 1 {
+                    return retval
+                } // If there are no predates for the following month,
+                  // then there are no counterpart dates
+                let lastDateOfCurrentMonth =
+                    Date.endOfMonth(for: date, using: calendar)!
+                let lastDay = calendar.component(.day,
+                                                 from: lastDateOfCurrentMonth)
                 let section = followingMonthInfo.startSection
-                let index = dayIndex - lastDay + (followingMonthInfo.preDates - 1)
-                if index < 0 { return retval }
+                let index = dayIndex - lastDay +
+                    (followingMonthInfo.preDates - 1)
+                if index < 0 {
+                    return retval
+                }
                 retval = IndexPath(item: index, section: section)
             }
         }
         return retval
     }
-    func scrollToSection(_ section: Int, triggerScrollToDateDelegate: Bool = false, animateScroll: Bool = true, completionHandler: (() -> Void)?) {
-        if scrollInProgress { return }
-        if let date = dateInfoFromPath(IndexPath(item: maxNumberOfDaysInWeek - 1, section:section))?.date {
-            let recalcDate = Date.startOfMonth(for: date, using: calendar)!
-            self.scrollToDate(recalcDate,
-                              triggerScrollToDateDelegate: triggerScrollToDateDelegate,
-                              animateScroll: animateScroll,
-                              preferredScrollPosition: nil,
-                              completionHandler: completionHandler)
+
+    func scrollToSection(_ section: Int,
+                         triggerScrollToDateDelegate: Bool = false,
+                         animateScroll: Bool = true,
+                         completionHandler: (() -> Void)?) {
+        if scrollInProgress {
+            return
+        }
+        if let date = dateInfoFromPath(IndexPath(
+            item: maxNumberOfDaysInWeek - 1, section: section))?.date {
+                let recalcDate = Date.startOfMonth(for: date,
+                                                   using: calendar)!
+                self.scrollToDate(recalcDate,
+                                  triggerScrollToDateDelegate:
+                                      triggerScrollToDateDelegate,
+                                  animateScroll: animateScroll,
+                                  preferredScrollPosition: nil,
+                                  completionHandler: completionHandler)
         }
     }
+
     func setupMonthInfoDataForStartAndEndDate() -> CalendarData {
         var months = [Month]()
-        var monthMap = [Int:Int]()
+        var monthMap = [Int: Int]()
         var totalSections = 0
         var totalDays = 0
         if let validConfig = dataSource?.configureCalendar(self) {
             // check if the dates are in correct order
-            if validConfig.calendar.compare(validConfig.startDate, to: validConfig.endDate, toGranularity: .nanosecond) == ComparisonResult.orderedDescending {
-                assert(false, "Error, your start date cannot be greater than your end date\n")
-                return (CalendarData(months:[], totalSections: 0, monthMap: [:], totalDays: 0))
+            if validConfig.calendar.compare(
+                validConfig.startDate, to: validConfig.endDate,
+                toGranularity: .nanosecond) ==
+                    ComparisonResult.orderedDescending {
+                        assert(false, "Error, your start date cannot be " +
+                            "greater than your end date\n")
+                        return (CalendarData(months: [], totalSections: 0,
+                                             monthMap: [:], totalDays: 0))
             }
             // Set the new cache
             cachedConfiguration = validConfig
             if let
-                startMonth = Date.startOfMonth(for: validConfig.startDate, using: validConfig.calendar),
-                let endMonth = Date.endOfMonth(for: validConfig.endDate, using: validConfig.calendar) {
+                startMonth = Date.startOfMonth(for: validConfig.startDate,
+                                               using: validConfig.calendar),
+                let endMonth = Date.endOfMonth(for: validConfig.endDate,
+                                               using: validConfig.calendar) {
                 startOfMonthCache = startMonth
                 endOfMonthCache   = endMonth
                 // Create the parameters for the date format generator
-                let parameters = DateConfigParameters(inCellGeneration: validConfig.generateInDates,
-                                                      outCellGeneration: validConfig.generateOutDates,
-                                                      numberOfRows: validConfig.numberOfRows,
-                                                      startOfMonthCache: startOfMonthCache,
-                                                      endOfMonthCache: endOfMonthCache,
-                                                      configuredCalendar: validConfig.calendar,
-                                                      firstDayOfWeek: validConfig.firstDayOfWeek)
-                let generatedData        = dateGenerator.setupMonthInfoDataForStartAndEndDate(parameters)
+                let parameters = DateConfigParameters(
+                    inCellGeneration: validConfig.generateInDates,
+                    outCellGeneration: validConfig.generateOutDates,
+                    numberOfRows: validConfig.numberOfRows,
+                    startOfMonthCache: startOfMonthCache,
+                    endOfMonthCache: endOfMonthCache,
+                    configuredCalendar: validConfig.calendar,
+                    firstDayOfWeek: validConfig.firstDayOfWeek)
+                let generatedData = dateGenerator
+                    .setupMonthInfoDataForStartAndEndDate(parameters)
                 months = generatedData.months
                 monthMap = generatedData.monthMap
                 totalSections = generatedData.totalSections
                 totalDays = generatedData.totalDays
             }
         }
-        let data = CalendarData(months: months, totalSections: totalSections, monthMap: monthMap, totalDays: totalDays)
+        let data = CalendarData(months: months, totalSections: totalSections,
+                                monthMap: monthMap, totalDays: totalDays)
         return data
     }
+
     func pathsFromDates(_ dates: [Date]) -> [IndexPath] {
         var returnPaths: [IndexPath] = []
         for date in dates {
-            if  calendar.startOfDay(for: date) >= startOfMonthCache && calendar.startOfDay(for: date) <= endOfMonthCache {
-                if  calendar.startOfDay(for: date) >= startOfMonthCache && calendar.startOfDay(for: date) <= endOfMonthCache {
-                    let periodApart = calendar.dateComponents([.month], from: startOfMonthCache, to: date)
+            if  calendar.startOfDay(for: date) >= startOfMonthCache &&
+                        calendar.startOfDay(for: date) <= endOfMonthCache {
+                if  calendar.startOfDay(for: date) >= startOfMonthCache &&
+                        calendar.startOfDay(for: date) <= endOfMonthCache {
+
+                    let periodApart = calendar.dateComponents([.month],
+                                        from: startOfMonthCache, to: date)
                     let day = calendar.dateComponents([.day], from: date).day!
                     let monthSectionIndex = periodApart.month
                     let currentMonthInfo = monthInfo[monthSectionIndex!]
-                    if let indexPath = currentMonthInfo.indexPath(forDay: day) {
-                        returnPaths.append(indexPath)
+                    if let indexPath = currentMonthInfo
+                        .indexPath(forDay: day) {
+                            returnPaths.append(indexPath)
                     }
                 }
             }
         }
         return returnPaths
     }
-    func cellStateFromIndexPath(_ indexPath: IndexPath, withDateInfo info: (date: Date, owner: DateOwner)? = nil, cell: JTAppleDayCell? = nil) -> CellState {
+
+    func cellStateFromIndexPath(_ indexPath: IndexPath,
+                withDateInfo info: (date: Date, owner: DateOwner)? = nil,
+                cell: JTAppleDayCell? = nil) -> CellState {
         let validDateInfo: (date: Date, owner: DateOwner)
         if let nonNilDateInfo = info {
             validDateInfo = nonNilDateInfo
         } else {
             guard let newDateInfo = dateInfoFromPath(indexPath) else {
-                developerError(string: "Error this should not be nil. Contact developer Jay on github by opening a request")
+                developerError(string: "Error this should not be nil. " +
+                    "Contact developer Jay on github by opening a request")
                 return CellState(isSelected: false,
                                  text: "",
                                  dateBelongsTo: .thisMonth,
@@ -641,7 +929,10 @@ extension JTAppleCalendarView {
                                  day: .sunday,
                                  row: {return 0},
                                  column: {return 0},
-                                 dateSection: {return (range: (Date(), Date()), month: 0, rowsForSection: 0)},
+                                 dateSection: {
+                                    return (range: (Date(), Date()),
+                                            month: 0, rowsForSection: 0)
+                                 },
                                  selectedPosition: {return .left},
                                  cell: {return nil})
             }
@@ -653,15 +944,29 @@ extension JTAppleCalendarView {
         let componentWeekDay = calendar.component(.weekday, from: date)
         let cellText = String(describing: currentDay)
         let dayOfWeek = DaysOfWeek(rawValue: componentWeekDay)!
-        let rangePosition = {() -> SelectionRangePosition in
+        let rangePosition = { () -> SelectionRangePosition in
             if self.theSelectedIndexPaths.contains(indexPath) {
-                if self.selectedDates.count == 1 { return .full}
-                let left = self.theSelectedIndexPaths.contains(IndexPath(item: indexPath.item - 1, section: indexPath.section))
-                let right = self.theSelectedIndexPaths.contains(IndexPath(item: indexPath.item + 1, section: indexPath.section))
+                if self.selectedDates.count == 1 {
+                    return .full
+                }
+                let left = self.theSelectedIndexPaths
+                    .contains(IndexPath(item: indexPath.item - 1,
+                                        section: indexPath.section))
+                let right = self.theSelectedIndexPaths
+                    .contains(IndexPath(item: indexPath.item + 1,
+                                        section: indexPath.section))
                 if left == right {
-                    if left == false { return .full } else { return .middle }
+                    if left == false {
+                        return .full
+                    } else {
+                        return .middle
+                    }
                 } else {
-                    if left == false { return .left } else { return .right }
+                    if left == false {
+                        return .left
+                    } else {
+                        return .right
+                    }
                 }
             }
             return .none
@@ -674,69 +979,99 @@ extension JTAppleCalendarView {
             day: dayOfWeek,
             row: { return indexPath.item / maxNumberOfDaysInWeek },
             column: { return indexPath.item % maxNumberOfDaysInWeek },
-            dateSection: { return self.monthInfoFromSection(indexPath.section)! },
+            dateSection: {
+                return self.monthInfoFromSection(indexPath.section)!
+            },
             selectedPosition: rangePosition,
             cell: {return cell}
         )
         return cellState
     }
+
     func batchReloadIndexPaths(_ indexPaths: [IndexPath]) {
-        if indexPaths.count < 1 { return }
-        UICollectionView.performWithoutAnimation({
+        if indexPaths.count < 1 {
+            return
+        }
+        UICollectionView.performWithoutAnimation {
             self.calendarView.performBatchUpdates({
                 self.calendarView.reloadItems(at: indexPaths)
                 }, completion: nil)
-        })
+        }
     }
-    func addCellToSelectedSetIfUnselected(_ indexPath: IndexPath, date: Date) {
+
+    func addCellToSelectedSetIfUnselected(_ indexPath: IndexPath,
+                                          date: Date) {
         if self.theSelectedIndexPaths.contains(indexPath) == false {
             self.theSelectedIndexPaths.append(indexPath)
             self.theSelectedDates.append(date)
         }
     }
+
     func deleteCellFromSelectedSetIfSelected(_ indexPath: IndexPath) {
         if let index = self.theSelectedIndexPaths.index(of: indexPath) {
             self.theSelectedIndexPaths.remove(at: index)
             self.theSelectedDates.remove(at: index)
         }
     }
-    func deselectCounterPartCellIndexPath(_ indexPath: IndexPath, date: Date, dateOwner: DateOwner) -> IndexPath? {
-        if let
-            counterPartCellIndexPath = indexPathOfdateCellCounterPart(date, indexPath: indexPath, dateOwner: dateOwner) {
+
+    func deselectCounterPartCellIndexPath(_ indexPath: IndexPath,
+                        date: Date, dateOwner: DateOwner) -> IndexPath? {
+        if let counterPartCellIndexPath =
+            indexPathOfdateCellCounterPart(date, indexPath: indexPath,
+                                           dateOwner: dateOwner) {
             deleteCellFromSelectedSetIfSelected(counterPartCellIndexPath)
             return counterPartCellIndexPath
         }
         return nil
     }
-    func selectCounterPartCellIndexPathIfExists(_ indexPath: IndexPath, date: Date, dateOwner: DateOwner) -> IndexPath? {
-        if let counterPartCellIndexPath = indexPathOfdateCellCounterPart(date, indexPath: indexPath, dateOwner: dateOwner) {
-            let dateComps = calendar.dateComponents([.month, .day, .year], from: date)
-            guard let counterpartDate = calendar.date(from: dateComps) else { return nil }
-            addCellToSelectedSetIfUnselected(counterPartCellIndexPath, date:counterpartDate)
+
+    func selectCounterPartCellIndexPathIfExists(_ indexPath: IndexPath,
+                            date: Date, dateOwner: DateOwner) -> IndexPath? {
+        if let counterPartCellIndexPath =
+                indexPathOfdateCellCounterPart(date, indexPath: indexPath,
+                                               dateOwner: dateOwner) {
+            let dateComps = calendar
+                .dateComponents([.month, .day, .year], from: date)
+            guard let counterpartDate = calendar
+                .date(from: dateComps) else { return nil }
+            addCellToSelectedSetIfUnselected(counterPartCellIndexPath,
+                                             date: counterpartDate)
             return counterPartCellIndexPath
         }
         return nil
     }
-    func monthInfoFromSection(_ section: Int) -> (range: (start: Date, end: Date), month: Int, rowsForSection: Int)? {
-        let monthIndex = monthMap[section]!
-        let monthData = monthInfo[monthIndex]
-        let startIndex = monthData.preDates
-        let endIndex = monthData.numberOfDaysInMonth + startIndex - 1
-        let startIndexPath = IndexPath(item: startIndex, section: section)
-        let endIndexPath = IndexPath(item: endIndex, section: section)
-        guard let
-            startDate = dateInfoFromPath(startIndexPath)?.date,
-            let endDate = dateInfoFromPath(endIndexPath)?.date else {
-                return nil
-        }
-        if let monthDate = calendar.date(byAdding: .month, value: monthIndex, to: startDateCache) {
-            let monthNumber = calendar.dateComponents([.month], from: monthDate)
-            let numberOfRowsForSection  = monthData.numberOfRows(for: section, developerSetRows: numberOfRows())
-            return ((startDate, endDate), monthNumber.month!, numberOfRowsForSection)
-        }
-        return nil
+
+    func monthInfoFromSection(_ section: Int) ->
+        (range: (start: Date, end: Date), month: Int, rowsForSection: Int)? {
+            let monthIndex = monthMap[section]!
+            let monthData = monthInfo[monthIndex]
+            let startIndex = monthData.preDates
+            let endIndex = monthData.numberOfDaysInMonth + startIndex - 1
+            let startIndexPath = IndexPath(item: startIndex, section: section)
+            let endIndexPath = IndexPath(item: endIndex, section: section)
+            guard let
+                startDate = dateInfoFromPath(startIndexPath)?.date,
+                let endDate = dateInfoFromPath(endIndexPath)?.date else {
+                    return nil
+            }
+            if let monthDate = calendar.date(byAdding: .month,
+                                             value: monthIndex,
+                                             to: startDateCache) {
+                let monthNumber = calendar.dateComponents([.month],
+                                                          from: monthDate)
+                let numberOfRowsForSection =
+                    monthData.numberOfRows(for: section,
+                                           developerSetRows: numberOfRows())
+                return ((startDate, endDate),
+                        monthNumber.month!,
+                        numberOfRowsForSection)
+            }
+            return nil
     }
-    func dateInfoFromPath(_ indexPath: IndexPath)-> (date: Date, owner: DateOwner)? { // Returns nil if date is out of scope
+
+    func dateInfoFromPath(_ indexPath: IndexPath) -> (date: Date,
+                                                     owner: DateOwner)? {
+                                   // Returns nil if date is out of scope
         guard let monthIndex = monthMap[indexPath.section] else {
             return nil
         }
@@ -748,25 +1083,32 @@ extension JTAppleCalendarView {
             offSet = monthData.preDates
         default:
             offSet = 0
-            let currentSectionIndexMap = monthData.sectionIndexMaps[indexPath.section]!
-            numberOfDaysToAddToOffset = monthData.sections[0..<currentSectionIndexMap].reduce(0, +)
+            let currentSectionIndexMap =
+                monthData.sectionIndexMaps[indexPath.section]!
+            numberOfDaysToAddToOffset =
+                monthData.sections[0..<currentSectionIndexMap].reduce(0, +)
             numberOfDaysToAddToOffset -= monthData.preDates
         }
         var dayIndex = 0
         var dateOwner: DateOwner = .thisMonth
         let date: Date?
         var dateComponents = DateComponents()
-        if indexPath.item >= offSet && indexPath.item + numberOfDaysToAddToOffset < monthData.numberOfDaysInMonth + offSet {
+        if indexPath.item >= offSet && indexPath.item +
+            numberOfDaysToAddToOffset <
+            monthData.numberOfDaysInMonth + offSet {
             // This is a month date
-            dayIndex = monthData.startDayIndex + indexPath.item - offSet + numberOfDaysToAddToOffset
+            dayIndex = monthData.startDayIndex +
+                indexPath.item - offSet + numberOfDaysToAddToOffset
             dateComponents.day = dayIndex
-            date = calendar.date(byAdding: dateComponents, to: startOfMonthCache)
+            date = calendar.date(byAdding: dateComponents,
+                                 to: startOfMonthCache)
             dateOwner = .thisMonth
         } else if indexPath.item < offSet {
             // This is a preDate
             dayIndex = indexPath.item - offSet  + monthData.startDayIndex
             dateComponents.day = dayIndex
-            date = calendar.date(byAdding: dateComponents, to: startOfMonthCache)
+            date = calendar.date(byAdding: dateComponents,
+                                 to: startOfMonthCache)
             if date! < startOfMonthCache {
                 dateOwner = .previousMonthOutsideBoundary
             } else {
@@ -774,9 +1116,11 @@ extension JTAppleCalendarView {
             }
         } else {
             // This is a postDate
-            dayIndex =  monthData.startDayIndex - offSet + indexPath.item + numberOfDaysToAddToOffset
+            dayIndex =  monthData.startDayIndex - offSet +
+                indexPath.item + numberOfDaysToAddToOffset
             dateComponents.day = dayIndex
-            date = calendar.date(byAdding: dateComponents, to: startOfMonthCache)
+            date = calendar.date(byAdding: dateComponents,
+                                 to: startOfMonthCache)
             if date! > endOfMonthCache {
                 dateOwner = .followingMonthOutsideBoundary
             } else {
@@ -786,4 +1130,5 @@ extension JTAppleCalendarView {
         guard let validDate = date else { return nil }
         return (validDate, dateOwner)
     }
+
 }

--- a/Sources/JTAppleCollectionReusableView.swift
+++ b/Sources/JTAppleCollectionReusableView.swift
@@ -7,16 +7,22 @@
 //
 
 /// The header view class of the calendar
-open class JTAppleCollectionReusableView: UICollectionReusableView, JTAppleReusableViewProtocol {
+open class JTAppleCollectionReusableView: UICollectionReusableView,
+                                          JTAppleReusableViewProtocol {
     var view: JTAppleHeaderView?
+
     func update() {
         view!.frame = self.frame
-        view!.center = CGPoint(x: self.bounds.size.width * 0.5, y: self.bounds.size.height * 0.5)
+        view!.center = CGPoint(x: self.bounds.size.width * 0.5,
+                               y: self.bounds.size.height * 0.5)
     }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
-    /// Returns an object initialized from data in a given unarchiver. self, initialized using the data in decoder.
+
+    /// Returns an object initialized from data in a given unarchiver.
+    // self, initialized using the data in decoder.
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }

--- a/Sources/JTAppleDayCell.swift
+++ b/Sources/JTAppleDayCell.swift
@@ -6,14 +6,19 @@
 //  Copyright © 2016 OS-Tech. All rights reserved.
 //
 
-/// The JTAppleDayCell class defines the attributes and behavior of the cells that appear in JTAppleCalendarView objects.
+/// The JTAppleDayCell class defines the attributes and
+/// behavior of the cells that appear in JTAppleCalendarView objects.
 open class JTAppleDayCell: UICollectionViewCell, JTAppleReusableViewProtocol {
+
 	var view: JTAppleDayCellView?
+
     func updateCellView(_ cellInsetX: CGFloat, cellInsetY: CGFloat) {
         let vFrame = self.frame.insetBy(dx: cellInsetX, dy: cellInsetY)
         view!.frame = vFrame
-        view!.center = CGPoint(x: self.bounds.size.width * 0.5, y: self.bounds.size.height * 0.5)
+        view!.center = CGPoint(x: self.bounds.size.width * 0.5,
+                               y: self.bounds.size.height * 0.5)
 	}
+
 	override init(frame: CGRect) {
 		super.init(frame: frame)
 	}
@@ -22,4 +27,5 @@ open class JTAppleDayCell: UICollectionViewCell, JTAppleReusableViewProtocol {
 	required public init?(coder aDecoder: NSCoder) {
 		super.init(coder: aDecoder)
 	}
+
 }

--- a/Sources/JTAppleReusableViewProtocol.swift
+++ b/Sources/JTAppleReusableViewProtocol.swift
@@ -13,6 +13,7 @@ internal protocol JTAppleReusableViewProtocol: class {
 }
 
 extension JTAppleReusableViewProtocol {
+
     func setupView(_ cellSource: JTAppleCalendarViewSource) {
         if let nonNilView = view {
             nonNilView.setNeedsLayout()
@@ -21,9 +22,11 @@ extension JTAppleReusableViewProtocol {
         switch cellSource {
         case let .fromXib(xibName, bundle):
             let bundleToUse = bundle ?? Bundle.main
-            let viewObject = bundleToUse.loadNibNamed(xibName, owner: self, options: [:])
+            let viewObject = bundleToUse
+                .loadNibNamed(xibName, owner: self, options: [:])
             guard let view = viewObject?[0] as? ViewType else {
-                print("xib: \(xibName),  file class does not conform to the JTAppleViewProtocol")
+                print("xib: \(xibName), " +
+                    "file class does not conform to the JTAppleViewProtocol")
                 assert(false)
                 return
             }
@@ -31,19 +34,24 @@ extension JTAppleReusableViewProtocol {
             break
         case let .fromClassName(className, bundle):
             let bundleToUse = bundle ?? Bundle.main
-            guard let theCellClass = bundleToUse.classNamed(className) as? ViewType.Type else {
-                print("Error loading registered class: '\(className)'")
-                print("Make sure that: \n\n(1) It is a subclass of: 'UIView' and conforms to 'JTAppleViewProtocol'")
-                print("(2) You registered your class using the fully qualified name like so -->  'theNameOfYourProject.theNameOfYourClass'\n")
-                assert(false)
-                return
+            guard let theCellClass =
+                bundleToUse.classNamed(className) as? ViewType.Type else {
+                    print("Error loading registered class: '\(className)'")
+                    print("Make sure that: \n\n(1) It is a subclass of: " +
+                        "'UIView' and conforms to 'JTAppleViewProtocol'")
+                    print("(2) You registered your class using the fully " +
+                        "qualified name like so --> " +
+                        "'theNameOfYourProject.theNameOfYourClass'\n")
+                    assert(false)
+                    return
             }
             self.view = theCellClass.init()
             break
         case let .fromType(cellType):
             guard let theCellClass = cellType as? ViewType.Type else {
                 print("Error loading registered class: '\(cellType)'")
-                print("Make sure that: \n\n(1) It is a subclass of: 'UIiew' and conforms to 'JTAppleViewProtocol'\n")
+                print("Make sure that: \n\n(1) It is a subclass of: " +
+                    "'UIiew' and conforms to 'JTAppleViewProtocol'\n")
                 assert(false)
                 return
             }
@@ -58,4 +66,5 @@ extension JTAppleReusableViewProtocol {
         }
         validSelf.addSubview(validView)
     }
+
 }

--- a/Sources/JTAppleViews.swift
+++ b/Sources/JTAppleViews.swift
@@ -6,12 +6,14 @@
 //  Copyright © 2016 OS-Tech. All rights reserved.
 //
 
-/// A day-cell view. The custom day-cells that you create should be a subclass of JTAppleDayCellView
+/// A day-cell view. The custom day-cells that you
+/// create should be a subclass of JTAppleDayCellView
 open class JTAppleDayCellView: UIView, JTAppleViewProtocol {
 }
 
 
-/// A header view. The custom headerview that you create should be a subclass of JTAppleHeaderView
+/// A header view. The custom headerview that you create
+/// should be a subclass of JTAppleHeaderView
 open class JTAppleHeaderView: UIView, JTAppleViewProtocol {
 }
 

--- a/Sources/JTCalendarProtocols.swift
+++ b/Sources/JTCalendarProtocols.swift
@@ -8,96 +8,193 @@
 
 /// Default delegate functions
 public extension JTAppleCalendarViewDelegate {
-    func calendar(_ calendar: JTAppleCalendarView, canSelectDate date: Date, cell: JTAppleDayCellView, cellState: CellState) -> Bool { return true }
-    func calendar(_ calendar: JTAppleCalendarView, canDeselectDate date: Date, cell: JTAppleDayCellView, cellState: CellState) -> Bool {return true}
-    func calendar(_ calendar: JTAppleCalendarView, didSelectDate date: Date, cell: JTAppleDayCellView?, cellState: CellState) {}
-    func calendar(_ calendar: JTAppleCalendarView, didDeselectDate date: Date, cell: JTAppleDayCellView?, cellState: CellState) {}
-    func calendar(_ calendar: JTAppleCalendarView, didScrollToDateSegmentFor range: (start: Date, end: Date), belongingTo month: Int, rows: Int) {}
-    func calendar(_ calendar: JTAppleCalendarView, willDisplayCell cell: JTAppleDayCellView, date: Date, cellState: CellState) {}
-    func calendar(_ calendar: JTAppleCalendarView, willResetCell cell: JTAppleDayCellView) {}
-    func calendar(_ calendar: JTAppleCalendarView, willDisplaySectionHeader header: JTAppleHeaderView, range: (start: Date, end: Date), identifier: String) {}
-    func calendar(_ calendar: JTAppleCalendarView, sectionHeaderIdentifierFor range: (start: Date, end: Date), belongingTo month: Int) -> String {return ""}
-    func calendar(_ calendar: JTAppleCalendarView, sectionHeaderSizeFor range: (start: Date, end: Date), belongingTo month: Int) -> CGSize {return CGSize.zero}
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  canSelectDate date: Date,
+                  cell: JTAppleDayCellView,
+                  cellState: CellState) -> Bool {
+        return true
+    }
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  canDeselectDate date: Date,
+                  cell: JTAppleDayCellView,
+                  cellState: CellState) -> Bool {
+        return true
+    }
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didSelectDate date: Date,
+                  cell: JTAppleDayCellView?,
+                  cellState: CellState) {}
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didDeselectDate date: Date,
+                  cell: JTAppleDayCellView?,
+                  cellState: CellState) {}
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didScrollToDateSegmentFor range: (start: Date, end: Date),
+                  belongingTo month: Int, rows: Int) {}
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willDisplayCell cell: JTAppleDayCellView,
+                  date: Date, cellState: CellState) {}
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willResetCell cell: JTAppleDayCellView) {}
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willDisplaySectionHeader header: JTAppleHeaderView,
+                  range: (start: Date, end: Date), identifier: String) {}
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  sectionHeaderIdentifierFor range: (start: Date, end: Date),
+                  belongingTo month: Int) -> String {
+        return ""
+    }
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  sectionHeaderSizeFor range: (start: Date, end: Date),
+                  belongingTo month: Int) -> CGSize {
+        return CGSize.zero
+    }
+
 }
 
-/// The JTAppleCalendarViewDataSource protocol is adopted by an object that mediates the application’s data model for a JTAppleCalendarViewDataSource object.
-/// The data source provides the calendar-view object with the information it needs to construct and modify it self
+/// The JTAppleCalendarViewDataSource protocol is adopted by an
+/// The object that mediates the application’s data model for a
+/// The JTAppleCalendarViewDataSource object. data source provides the
+/// The calendar-view object with the information it needs to construct and
+/// The modify it self
 public protocol JTAppleCalendarViewDataSource: class {
-    /// Asks the data source to return the start and end boundary dates as well as the calendar to use. You should properly configure your calendar at this point.
+    /// Asks the data source to return the start and end boundary dates
+    /// as well as the calendar to use. You should properly configure
+    /// your calendar at this point.
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view requesting this information.
     /// - returns:
     ///     - ConfigurationParameters instance:
-    func configureCalendar(_ calendar: JTAppleCalendarView) -> ConfigurationParameters
+    func configureCalendar(
+        _ calendar: JTAppleCalendarView) -> ConfigurationParameters
 }
 
-/// The delegate of a JTAppleCalendarView object must adopt the JTAppleCalendarViewDelegate protocol.
-/// Optional methods of the protocol allow the delegate to manage selections, and configure the cells.
+/// The delegate of a JTAppleCalendarView object must adopt the              .
+/// JTAppleCalendarViewDelegate protocol Optional methods of the protocol    .
+/// allow the delegate to manage selections, and configure the cells         .
 public protocol JTAppleCalendarViewDelegate: class {
-    /// Asks the delegate if selecting the date-cell with a specified date is allowed
+
+    /// Asks the delegate if selecting the date-cell with a specified date is
+    /// allowed
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view requesting this information.
     ///     - date: The date attached to the date-cell.
     ///     - cell: The date-cell view. This can be customized at this point.
     ///     - cellState: The month the date-cell belongs to.
     /// - returns: A Bool value indicating if the operation can be done.
-    func calendar(_ calendar: JTAppleCalendarView, canSelectDate date: Date, cell: JTAppleDayCellView, cellState: CellState) -> Bool
-    /// Asks the delegate if de-selecting the date-cell with a specified date is allowed
+    func calendar(_ calendar: JTAppleCalendarView,
+                  canSelectDate date: Date,
+                  cell: JTAppleDayCellView,
+                  cellState: CellState) -> Bool
+
+    /// Asks the delegate if de-selecting the
+    /// date-cell with a specified date is allowed
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view requesting this information.
     ///     - date: The date attached to the date-cell.
     ///     - cell: The date-cell view. This can be customized at this point.
     ///     - cellState: The month the date-cell belongs to.
     /// - returns: A Bool value indicating if the operation can be done.
-    func calendar(_ calendar: JTAppleCalendarView, canDeselectDate date: Date, cell: JTAppleDayCellView, cellState: CellState) -> Bool
+    func calendar(_ calendar: JTAppleCalendarView,
+                  canDeselectDate date: Date,
+                  cell: JTAppleDayCellView,
+                  cellState: CellState) -> Bool
+
     /// Tells the delegate that a date-cell with a specified date was selected
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view giving this information.
     ///     - date: The date attached to the date-cell.
-    ///     - cell: The date-cell view. This can be customized at this point. This may be nil if the selected cell is off the screen
+    ///     - cell: The date-cell view. This can be customized at this point.
+    ///             This may be nil if the selected cell is off the screen
     ///     - cellState: The month the date-cell belongs to.
-    func calendar(_ calendar: JTAppleCalendarView, didSelectDate date: Date, cell: JTAppleDayCellView?, cellState: CellState)
-    /// Tells the delegate that a date-cell with a specified date was de-selected
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didSelectDate date: Date,
+                  cell: JTAppleDayCellView?,
+                  cellState: CellState)
+    /// Tells the delegate that a date-cell
+    /// with a specified date was de-selected
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view giving this information.
     ///     - date: The date attached to the date-cell.
-    ///     - cell: The date-cell view. This can be customized at this point. This may be nil if the selected cell is off the screen
+    ///     - cell: The date-cell view. This can be customized at this point.
+    ///             This may be nil if the selected cell is off the screen
     ///     - cellState: The month the date-cell belongs to.
-    func calendar(_ calendar: JTAppleCalendarView, didDeselectDate date: Date, cell: JTAppleDayCellView?, cellState: CellState)
-    /// Tells the delegate that the JTAppleCalendar view scrolled to a segment beginning and ending with a particular date
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didDeselectDate date: Date,
+                  cell: JTAppleDayCellView?,
+                  cellState: CellState)
+
+    /// Tells the delegate that the JTAppleCalendar view
+    /// scrolled to a segment beginning and ending with a particular date
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view giving this information.
     ///     - startDate: The date at the start of the segment.
     ///     - endDate: The date at the end of the segment.
-    func calendar(_ calendar: JTAppleCalendarView, didScrollToDateSegmentFor range: (start: Date, end: Date), belongingTo month: Int, rows: Int)
-    /// Tells the delegate that the JTAppleCalendar is about to display a date-cell. This is the point of customization for your date cells
+    func calendar(_ calendar: JTAppleCalendarView,
+                  didScrollToDateSegmentFor range: (start: Date, end: Date),
+                  belongingTo month: Int, rows: Int)
+
+    /// Tells the delegate that the JTAppleCalendar is about to display
+    /// a date-cell. This is the point of customization for your date cells
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view giving this information.
     ///     - cell: The date-cell that is about to be displayed.
     ///     - date: The date attached to the cell.
     ///     - cellState: The month the date-cell belongs to.
-    func calendar(_ calendar: JTAppleCalendarView, willDisplayCell cell: JTAppleDayCellView, date: Date, cellState: CellState)
-    /// Tells the delegate that the JTAppleCalendar is about to reset a date-cell. Reset your cell here before being reused on screen. Make sure this function exits quicky.
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willDisplayCell cell: JTAppleDayCellView,
+                  date: Date, cellState: CellState)
+    /// Tells the delegate that the JTAppleCalendar is about to reset
+    /// a date-cell. Reset your cell here before being reused on screen.
+    /// Make sure this function exits quicky.
     /// - Parameters:
     ///     - cell: The date-cell that is about to be reset.
-    func calendar(_ calendar: JTAppleCalendarView, willResetCell cell: JTAppleDayCellView)
-    /// Implement this function to use headers in your project. Return your registered header for the date presented.
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willResetCell cell: JTAppleDayCellView)
+
+    /// Implement this function to use headers in your project.
+    /// Return your registered header for the date presented.
     /// - Parameters:
-    ///     - date: Contains the startDate and endDate for the header that is about to be displayed
+    ///     - date: Contains the startDate and endDate for the
+    ///             header that is about to be displayed
     /// - Returns:
     ///   String: Provide the registered header you wish to show for this date
-    func calendar(_ calendar: JTAppleCalendarView, sectionHeaderIdentifierFor range: (start: Date, end: Date), belongingTo month: Int) -> String
-    /// Implement this function to use headers in your project. Return the size for the header you wish to present
+    func calendar(_ calendar: JTAppleCalendarView,
+                  sectionHeaderIdentifierFor range: (start: Date, end: Date),
+                  belongingTo month: Int) -> String
+
+    /// Implement this function to use headers in your project.
+    /// Return the size for the header you wish to present
     /// - Parameters:
-    ///     - date: Contains the startDate and endDate for the header that is about to be displayed
+    ///     - date: Contains the startDate and endDate for
+    ///             the header that is about to be displayed
     /// - Returns:
-    ///   CGSize: Provide the size for the header you wish to show for this date
-    func calendar(_ calendar: JTAppleCalendarView, sectionHeaderSizeFor range: (start: Date, end: Date), belongingTo month: Int) -> CGSize
-    /// Tells the delegate that the JTAppleCalendar is about to display a header. This is the point of customization for your headers
+    ///   CGSize: Provide the size for the header
+    ///           you wish to show for this date
+
+    func calendar(_ calendar: JTAppleCalendarView,
+                  sectionHeaderSizeFor range: (start: Date, end: Date),
+                  belongingTo month: Int) -> CGSize
+
+    /// Tells the delegate that the JTAppleCalendar is about to
+    /// display a header. This is the point of customization for your headers
     /// - Parameters:
     ///     - calendar: The JTAppleCalendar view giving this information.
     ///     - header: The header view that is about to be displayed.
     ///     - date: The date attached to the header.
     ///     - identifier: The identifier you provided for the header
-    func calendar(_ calendar: JTAppleCalendarView, willDisplaySectionHeader header: JTAppleHeaderView, range: (start: Date, end: Date), identifier: String)
+    func calendar(_ calendar: JTAppleCalendarView,
+                  willDisplaySectionHeader header: JTAppleHeaderView,
+                  range: (start: Date, end: Date), identifier: String)
 }

--- a/Sources/UICollectionViewDelegates.swift
+++ b/Sources/UICollectionViewDelegates.swift
@@ -6,52 +6,80 @@
 //
 //
 
-extension JTAppleCalendarView: UICollectionViewDataSource, UICollectionViewDelegate {
-    /// Asks your data source object to provide a supplementary view to display in the collection view.
-    public func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        guard let validDate = monthInfoFromSection(indexPath.section) else {
-            assert(false, "Date could not be generated fro section. This is a bug. Contact the developer")
-            return UICollectionReusableView()
-        }
-        let reuseIdentifier: String
-        var source: JTAppleCalendarViewSource = registeredHeaderViews[0]
-        // Get the reuse identifier and index
-        if registeredHeaderViews.count == 1 {
-            switch registeredHeaderViews[0] {
-            case let .fromXib(xibName, _): reuseIdentifier = xibName
-            case let .fromClassName(className, _): reuseIdentifier = className
-            case let .fromType(classType): reuseIdentifier = classType.description()
+extension JTAppleCalendarView: UICollectionViewDelegate,
+                               UICollectionViewDataSource {
+
+    /// Asks your data source object to provide a
+    /// supplementary view to display in the collection view.
+    public func collectionView(_ collectionView: UICollectionView,
+        viewForSupplementaryElementOfKind kind: String,
+        at indexPath: IndexPath) -> UICollectionReusableView {
+
+            guard let validDate =
+                monthInfoFromSection(indexPath.section) else {
+                    assert(false,
+                        "Date could not be generated fro section. " +
+                        "This is a bug. Contact the developer")
+                    return UICollectionReusableView()
             }
-        } else {
-            reuseIdentifier = delegate!.calendar(self, sectionHeaderIdentifierFor: validDate.range, belongingTo: validDate.month)
-            for item in registeredHeaderViews {
-                switch item {
-                case let .fromXib(xibName, _) where xibName == reuseIdentifier:
-                    source = item
-                    break
-                case let .fromClassName(className, _) where className == reuseIdentifier:
-                    source = item
-                    break
-                case let .fromType(type) where type.description() == reuseIdentifier:
-                    source = item
-                    break
-                default:
-                    continue
+            let reuseIdentifier: String
+            var source: JTAppleCalendarViewSource = registeredHeaderViews[0]
+            // Get the reuse identifier and index
+            if registeredHeaderViews.count == 1 {
+                switch registeredHeaderViews[0] {
+                case let .fromXib(xibName, _):
+                    reuseIdentifier = xibName
+                case let .fromClassName(className, _):
+                    reuseIdentifier = className
+                case let .fromType(classType):
+                    reuseIdentifier = classType.description()
+                }
+            } else {
+                reuseIdentifier = delegate!.calendar(
+                    self,
+                    sectionHeaderIdentifierFor: validDate.range,
+                    belongingTo: validDate.month)
+                for item in registeredHeaderViews {
+                    switch item {
+                    case let .fromXib(xibName, _) where
+                        xibName == reuseIdentifier:
+                        source = item
+                        break
+                    case let .fromClassName(className, _) where
+                        className == reuseIdentifier:
+                        source = item
+                        break
+                    case let .fromType(type) where
+                        type.description() == reuseIdentifier:
+                        source = item
+                        break
+                    default:
+                        continue
+                    }
                 }
             }
-        }
-        guard let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind,
-                                                                               withReuseIdentifier: reuseIdentifier,
-                                                                               for: indexPath) as? JTAppleCollectionReusableView else {
-                                                                                developerError(string: "Headerview is not of type 'JTAppleCollectionReusableView'.")
-                                                                                return UICollectionReusableView()
-        }
-        headerView.setupView(source)
-        headerView.update()
-        self.delegate?.calendar(self, willDisplaySectionHeader: headerView.view!, range: validDate.range, identifier: reuseIdentifier)
-        return headerView
+            guard let headerView = collectionView
+                .dequeueReusableSupplementaryView(
+                    ofKind: kind,
+                    withReuseIdentifier: reuseIdentifier,
+                    for: indexPath) as? JTAppleCollectionReusableView else {
+                        developerError(string: "Headerview is not of type " +
+                            "'JTAppleCollectionReusableView'.")
+                        return UICollectionReusableView()
+            }
+            headerView.setupView(source)
+            headerView.update()
+            self.delegate?.calendar(
+                self,
+                willDisplaySectionHeader: headerView.view!,
+                range: validDate.range,
+                identifier: reuseIdentifier)
+            return headerView
     }
-    public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+
+    public func collectionView(_ collectionView: UICollectionView,
+                               didEndDisplaying cell: UICollectionViewCell,
+                               forItemAt indexPath: IndexPath) {
         guard #available(iOS 10, *) else {
             guard
                 let theCell = cell as? JTAppleDayCell,
@@ -63,126 +91,217 @@ extension JTAppleCalendarView: UICollectionViewDataSource, UICollectionViewDeleg
             return
         }
     }
-    /// Asks your data source object for the cell that corresponds to the specified item in the collection view.
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        restoreSelectionStateForCellAtIndexPath(indexPath)
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellReuseIdentifier, for: indexPath) as? JTAppleDayCell else {
-            developerError(string: "Cell was not of type JTAppleDayCell")
-            return UICollectionViewCell()
-        }
-        cell.setupView(cellViewSource)
-        cell.updateCellView(cellInset.x, cellInsetY: cellInset.y)
-        cell.bounds.origin = CGPoint(x: 0, y: 0)
-        let cellState = cellStateFromIndexPath(indexPath)
-        delegate?.calendar(self, willDisplayCell: cell.view!, date: cellState.date, cellState: cellState)
-        
-        return cell
+
+    /// Asks your data source object for the cell that corresponds
+    /// to the specified item in the collection view.
+    public func collectionView(_ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+            restoreSelectionStateForCellAtIndexPath(indexPath)
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: cellReuseIdentifier,
+                for: indexPath) as? JTAppleDayCell else {
+                    developerError(string:
+                        "Cell was not of type JTAppleDayCell")
+                    return UICollectionViewCell()
+            }
+            cell.setupView(cellViewSource)
+            cell.updateCellView(cellInset.x, cellInsetY: cellInset.y)
+            cell.bounds.origin = CGPoint(x: 0, y: 0)
+            let cellState = cellStateFromIndexPath(indexPath)
+            delegate?.calendar(self, willDisplayCell:
+                cell.view!, date: cellState.date, cellState: cellState)
+
+            return cell
     }
-    /// Asks your data source object for the number of sections in the collection view. The number of sections in collectionView.
+
+    /// Asks your data sourceobject for the number of sections in
+    /// the collection view. The number of sections in collectionView.
     public func numberOfSections(in collectionView: UICollectionView) -> Int {
         return monthMap.count
     }
-    
-    /// Asks your data source object for the number of items in the specified section. The number of rows in section.
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        guard
-            let count =  calendarViewLayout.cellCache[section]?.count else {
+
+
+    /// Asks your data source object for the number of items in the
+    /// specified section. The number of rows in section.
+    public func collectionView(_ collectionView: UICollectionView,
+                               numberOfItemsInSection section: Int) -> Int {
+        guard let count =  calendarViewLayout.cellCache[section]?.count else {
                 developerError(string: "cellCacheSection does not exist.")
                 return 0
         }
-        
+
         return count
     }
-    /// Asks the delegate if the specified item should be selected. true if the item should be selected or false if it should not.
-    public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        if let
-            delegate = self.delegate,
-            let infoOfDateUserSelected = dateInfoFromPath(indexPath),
-            let cell = collectionView.cellForItem(at: indexPath) as? JTAppleDayCell,
-            cellWasNotDisabledOrHiddenByTheUser(cell) {
-            let cellState = cellStateFromIndexPath(indexPath, withDateInfo: infoOfDateUserSelected)
-            return delegate.calendar(self, canSelectDate: infoOfDateUserSelected.date, cell: cell.view!, cellState: cellState)
-        }
-        return false
+
+    /// Asks the delegate if the specified item should be selected.
+    /// true if the item should be selected or false if it should not.
+    public func collectionView(_ collectionView: UICollectionView,
+        shouldSelectItemAt indexPath: IndexPath) -> Bool {
+            if let
+                delegate = self.delegate,
+                let infoOfDateUserSelected = dateInfoFromPath(indexPath),
+                let cell = collectionView
+                    .cellForItem(at: indexPath) as? JTAppleDayCell,
+                cellWasNotDisabledOrHiddenByTheUser(cell) {
+                let cellState = cellStateFromIndexPath(indexPath,
+                    withDateInfo: infoOfDateUserSelected)
+                return delegate.calendar(
+                    self,
+                    canSelectDate: infoOfDateUserSelected.date,
+                    cell: cell.view!,
+                    cellState: cellState
+                )
+            }
+            return false
     }
+
     func cellWasNotDisabledOrHiddenByTheUser(_ cell: JTAppleDayCell) -> Bool {
-        return cell.view!.isHidden == false && cell.view!.isUserInteractionEnabled == true
+        return cell.view!.isHidden == false &&
+            cell.view!.isUserInteractionEnabled == true
     }
+
     /// Tells the delegate that the item at the specified path was deselected.
-    /// The collection view calls this method when the user successfully deselects an item in the collection view.
+    /// The collection view calls this method when the user successfully
+    /// deselects an item in the collection view.
     /// It does not call this method when you programmatically deselect items.
-    public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
-        let indexPathsToBeReloaded = rangeSelectionWillBeUsed ? validForwardAndBackwordSelectedIndexes(forIndexPath: indexPath) : [IndexPath]()
-        internalCollectionView(collectionView, didDeselectItemAtIndexPath: indexPath, indexPathsToReload: indexPathsToBeReloaded)
+    public func collectionView(_ collectionView: UICollectionView,
+                               didDeselectItemAt indexPath: IndexPath) {
+        let indexPathsToBeReloaded = rangeSelectionWillBeUsed ?
+            validForwardAndBackwordSelectedIndexes(forIndexPath: indexPath) :
+            [IndexPath]()
+        internalCollectionView(collectionView,
+                               didDeselectItemAtIndexPath: indexPath,
+                               indexPathsToReload: indexPathsToBeReloaded)
     }
-    func internalCollectionView(_ collectionView: UICollectionView, didDeselectItemAtIndexPath indexPath: IndexPath, indexPathsToReload: [IndexPath] = []) {
-        if let
-            delegate = self.delegate,
-            let dateInfoDeselectedByUser = dateInfoFromPath(indexPath) {
-            // Update model
-            deleteCellFromSelectedSetIfSelected(indexPath)
-            let selectedCell = collectionView.cellForItem(at: indexPath) as? JTAppleDayCell // Cell may be nil if user switches month sections
-            // Although the cell may be nil, we still want to return the cellstate
-            let cellState = cellStateFromIndexPath(indexPath, withDateInfo: dateInfoDeselectedByUser, cell: selectedCell)
-            var pathsToReload = indexPathsToReload
-            if let unselectedCounterPartIndexPath = deselectCounterPartCellIndexPath(indexPath, date: dateInfoDeselectedByUser.date, dateOwner: cellState.dateBelongsTo) {
-                deleteCellFromSelectedSetIfSelected(unselectedCounterPartIndexPath)
-                // ONLY if the counterPart cell is visible, then we need to inform the delegate
-                if !pathsToReload.contains(unselectedCounterPartIndexPath) { pathsToReload.append(unselectedCounterPartIndexPath) }
-            }
-            if pathsToReload.count > 0 {
-                delayRunOnMainThread(0.0) {
-                    self.batchReloadIndexPaths(pathsToReload)
+
+    func internalCollectionView(_ collectionView: UICollectionView,
+        didDeselectItemAtIndexPath indexPath: IndexPath,
+        indexPathsToReload: [IndexPath] = []) {
+            if let
+                delegate = self.delegate,
+                let dateInfoDeselectedByUser = dateInfoFromPath(indexPath) {
+                // Update model
+                deleteCellFromSelectedSetIfSelected(indexPath)
+                let selectedCell = collectionView
+                    .cellForItem(at: indexPath) as? JTAppleDayCell
+                // Cell may be nil if user switches month sections
+                // Although the cell may be nil, we still want to
+                // return the cellstate
+                let cellState = cellStateFromIndexPath(
+                    indexPath,
+                    withDateInfo: dateInfoDeselectedByUser,
+                    cell: selectedCell
+                )
+                var pathsToReload = indexPathsToReload
+                let deselectCPCell = deselectCounterPartCellIndexPath(
+                        indexPath,
+                        date: dateInfoDeselectedByUser.date,
+                        dateOwner: cellState.dateBelongsTo)
+                if let unselectedCounterPartIndexPath = deselectCPCell {
+                    deleteCellFromSelectedSetIfSelected(
+                        unselectedCounterPartIndexPath)
+                    // ONLY if the counterPart cell is visible,
+                    // then we need to inform the delegate
+                    if !pathsToReload
+                        .contains(unselectedCounterPartIndexPath) {
+                            pathsToReload
+                                .append(unselectedCounterPartIndexPath)
+                    }
                 }
-            }
-            delegate.calendar(self, didDeselectDate: dateInfoDeselectedByUser.date, cell: selectedCell?.view, cellState: cellState)
-        }
-    }
-    /// Asks the delegate if the specified item should be deselected. true if the item should be deselected or false if it should not.
-    public func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
-        if let
-            delegate = self.delegate,
-            let infoOfDateDeSelectedByUser = dateInfoFromPath(indexPath),
-            let cell = collectionView.cellForItem(at: indexPath) as? JTAppleDayCell,
-            cellWasNotDisabledOrHiddenByTheUser(cell) {
-            let cellState = cellStateFromIndexPath(indexPath, withDateInfo: infoOfDateDeSelectedByUser)
-            return delegate.calendar(self, canDeselectDate: infoOfDateDeSelectedByUser.date, cell: cell.view!, cellState:  cellState)
-        }
-        return false
-    }
-    /// Tells the delegate that the item at the specified index path was selected.
-    /// The collection view calls this method when the user successfully selects an item in the collection view.
-    /// It does not call this method when you programmatically set the selection.
-    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        // index paths to be reloaded should be index to the left and right of the selected index
-        let indexPathsToBeReloaded = rangeSelectionWillBeUsed ? validForwardAndBackwordSelectedIndexes(forIndexPath: indexPath) : [IndexPath]()
-        internalCollectionView(collectionView, didSelectItemAtIndexPath: indexPath, indexPathsToReload: indexPathsToBeReloaded)
-    }
-    func internalCollectionView(_ collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: IndexPath, indexPathsToReload: [IndexPath] = []) {
-        if
-            let delegate = self.delegate,
-            let infoOfDateSelectedByUser = dateInfoFromPath(indexPath) {
-            // Update model
-            addCellToSelectedSetIfUnselected(indexPath, date:infoOfDateSelectedByUser.date)
-            let selectedCell = collectionView.cellForItem(at: indexPath) as? JTAppleDayCell
-            // If cell has a counterpart cell, then select it as well
-            let cellState = cellStateFromIndexPath(indexPath, withDateInfo: infoOfDateSelectedByUser, cell: selectedCell)
-            var pathsToReload = indexPathsToReload
-            if let selectedCounterPartIndexPath = selectCounterPartCellIndexPathIfExists(indexPath, date: infoOfDateSelectedByUser.date, dateOwner: cellState.dateBelongsTo) {
-                // ONLY if the counterPart cell is visible, then we need to inform the delegate
-                if !pathsToReload.contains(selectedCounterPartIndexPath) {
-                    pathsToReload.append(selectedCounterPartIndexPath)
+                if pathsToReload.count > 0 {
+                    delayRunOnMainThread(0.0) {
+                        self.batchReloadIndexPaths(pathsToReload)
+                    }
                 }
+                delegate.calendar(
+                    self,
+                    didDeselectDate: dateInfoDeselectedByUser.date,
+                    cell: selectedCell?.view,
+                    cellState: cellState
+                )
             }
-            if pathsToReload.count > 0 {
-                delayRunOnMainThread(0.0) {
-                    self.batchReloadIndexPaths(pathsToReload)
-                }
-            }
-            delegate.calendar(self, didSelectDate: infoOfDateSelectedByUser.date, cell: selectedCell?.view, cellState: cellState)
-            
-            
-            print("columns: \(cellStateFromIndexPath(indexPath).column()) row: \(cellStateFromIndexPath(indexPath).row())")
-        }
     }
+
+    /// Asks the delegate if the specified item should be deselected.
+    /// true if the item should be deselected or false if it should not.
+    public func collectionView(_ collectionView: UICollectionView,
+        shouldDeselectItemAt indexPath: IndexPath) -> Bool {
+            if let
+                delegate = self.delegate,
+                let infoOfDateDeSelectedByUser = dateInfoFromPath(indexPath),
+                let cell = collectionView
+                    .cellForItem(at: indexPath) as? JTAppleDayCell,
+                cellWasNotDisabledOrHiddenByTheUser(cell) {
+                let cellState = cellStateFromIndexPath(indexPath,
+                    withDateInfo: infoOfDateDeSelectedByUser)
+                return delegate.calendar(
+                    self,
+                    canDeselectDate: infoOfDateDeSelectedByUser.date,
+                    cell: cell.view!,
+                    cellState: cellState
+                )
+            }
+            return false
+    }
+
+    /// Tells the delegate that the item at the specified index
+    /// path was selected. The collection view calls this method when the
+    /// user successfully selects an item in the collection view.
+    /// It does not call this method when you programmatically
+    /// set the selection.
+    public func collectionView(_ collectionView: UICollectionView,
+                               didSelectItemAt indexPath: IndexPath) {
+        // index paths to be reloaded should be index
+        // to the left and right of the selected index
+        let indexPathsToBeReloaded = rangeSelectionWillBeUsed ?
+            validForwardAndBackwordSelectedIndexes(forIndexPath: indexPath) :
+            [IndexPath]()
+        internalCollectionView(collectionView,
+                               didSelectItemAtIndexPath: indexPath,
+                               indexPathsToReload: indexPathsToBeReloaded)
+    }
+
+    func internalCollectionView(_ collectionView: UICollectionView,
+                                didSelectItemAtIndexPath indexPath: IndexPath,
+                                indexPathsToReload: [IndexPath] = []) {
+        guard let delegate = self.delegate,
+            let infoOfDateSelectedByUser = dateInfoFromPath(indexPath) else {
+                return
+        }
+        // Update model
+        addCellToSelectedSetIfUnselected(indexPath,
+                                         date: infoOfDateSelectedByUser.date)
+        let selectedCell = collectionView
+            .cellForItem(at: indexPath) as? JTAppleDayCell
+        // If cell has a counterpart cell, then select it as well
+        let cellState = cellStateFromIndexPath(indexPath,
+            withDateInfo: infoOfDateSelectedByUser, cell: selectedCell)
+        var pathsToReload = indexPathsToReload
+        if let selectedCounterPartIndexPath =
+            selectCounterPartCellIndexPathIfExists(indexPath,
+                date: infoOfDateSelectedByUser.date,
+                dateOwner: cellState.dateBelongsTo) {
+                    // ONLY if the counterPart cell is visible,
+                    // then we need to inform the delegate
+                    if !pathsToReload.contains(selectedCounterPartIndexPath) {
+                        pathsToReload.append(selectedCounterPartIndexPath)
+                    }
+        }
+        if pathsToReload.count > 0 {
+            delayRunOnMainThread(0.0) {
+                self.batchReloadIndexPaths(pathsToReload)
+            }
+        }
+        delegate.calendar(
+            self,
+            didSelectDate: infoOfDateSelectedByUser.date,
+            cell: selectedCell?.view,
+            cellState: cellState
+        )
+
+        print("columns: \(cellStateFromIndexPath(indexPath).column()) " +
+            "row: \(cellStateFromIndexPath(indexPath).row())")
+
+    }
+
 }

--- a/Sources/UIScrollViewDelegates.swift
+++ b/Sources/UIScrollViewDelegates.swift
@@ -7,187 +7,295 @@
 //
 
 extension JTAppleCalendarView: UIScrollViewDelegate {
-    /// Inform the scrollViewDidEndDecelerating function that scrolling just occurred
+
+    /// Inform the scrollViewDidEndDecelerating
+    /// function that scrolling just occurred
     public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
         self.scrollViewDidEndDecelerating(calendarView)
     }
+
     /// Tells the delegate when the user finishes scrolling the content.
-    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-        let saveLastContentOffset = { self.lastSavedContentOffset = self.direction == .horizontal ? targetContentOffset.pointee.x : targetContentOffset.pointee.y }
-        let cachedDecelerationRate = calendarView.decelerationRate
-        let theCurrentSection = currentSectionPage
-        let contentSizeEndOffset: CGFloat
-        var contentOffset: CGFloat = 0,
-        theTargetContentOffset: CGFloat = 0,
-        directionVelocity: CGFloat = 0
-        let calendarLayout = self.calendarViewLayout
-        if direction == .horizontal {
-            contentOffset = scrollView.contentOffset.x
-            theTargetContentOffset = targetContentOffset.pointee.x
-            directionVelocity = velocity.x
-            contentSizeEndOffset = scrollView.contentSize.width - scrollView.frame.width
-        } else {
-            contentOffset = scrollView.contentOffset.y
-            theTargetContentOffset = targetContentOffset.pointee.y
-            directionVelocity = velocity.y
-            contentSizeEndOffset = scrollView.contentSize.height - scrollView.frame.height
-        }
-        let isScrollingForward = {return directionVelocity > 0 || contentOffset > self.lastSavedContentOffset}
-        let isNotScrolling = {return contentOffset == self.lastSavedContentOffset}
-        if isNotScrolling() { return }
-        if directionVelocity == 0.0 { calendarView.decelerationRate = UIScrollViewDecelerationRateFast }
-        let setTargetContentOffset = {(finalOffset: CGFloat) -> Void in
-            if self.direction == .horizontal {
-                targetContentOffset.pointee.x = finalOffset
-            } else {
-                targetContentOffset.pointee.y = finalOffset
+    public func scrollViewWillEndDragging(_ scrollView: UIScrollView,
+        withVelocity velocity: CGPoint,
+        targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+            let saveLastContentOffset = {
+                self.lastSavedContentOffset = self.direction == .horizontal ?
+                    targetContentOffset.pointee.x :
+                    targetContentOffset.pointee.y
             }
-        }
-        let calculatedCurrentFixedContentOffsetFrom = {(interval: CGFloat) -> CGFloat in
-            if isScrollingForward() {
-                return ceil(contentOffset / interval) * interval
+            let cachedDecelerationRate = calendarView.decelerationRate
+            let theCurrentSection = currentSectionPage
+            let contentSizeEndOffset: CGFloat
+            var contentOffset: CGFloat = 0,
+            theTargetContentOffset: CGFloat = 0,
+            directionVelocity: CGFloat = 0
+            let calendarLayout = self.calendarViewLayout
+            if direction == .horizontal {
+                contentOffset = scrollView.contentOffset.x
+                theTargetContentOffset = targetContentOffset.pointee.x
+                directionVelocity = velocity.x
+                contentSizeEndOffset =
+                    scrollView.contentSize.width - scrollView.frame.width
             } else {
-                return floor(contentOffset / interval) * interval
+                contentOffset = scrollView.contentOffset.y
+                theTargetContentOffset = targetContentOffset.pointee.y
+                directionVelocity = velocity.y
+                contentSizeEndOffset =
+                    scrollView.contentSize.height - scrollView.frame.height
             }
-        }
-        let recalculateOffset = {(diff: CGFloat, interval: CGFloat) -> CGFloat in
-            if isScrollingForward() {
-                let recalcOffsetAfterResistanceApplied = theTargetContentOffset - diff
-                return ceil(recalcOffsetAfterResistanceApplied / interval) * interval
-            } else {
-                let recalcOffsetAfterResistanceApplied = theTargetContentOffset + diff
-                return floor(recalcOffsetAfterResistanceApplied / interval) * interval
+            let isScrollingForward = {
+                return directionVelocity > 0 ||
+                    contentOffset > self.lastSavedContentOffset
             }
-        }
-        let scrollViewShouldStopAtBeginning = {() -> Bool in return contentOffset < 0 && theTargetContentOffset == 0 ? true : false}
-        let scrollViewShouldStopAtEnd = {(calculatedOffSet: CGFloat) -> Bool in return calculatedOffSet > contentSizeEndOffset }
-        switch scrollingMode {
-        case let .stopAtEach(customInterval: interval):
-            let calculatedOffset = calculatedCurrentFixedContentOffsetFrom(interval)
-            setTargetContentOffset(calculatedOffset)
-        case .stopAtEachCalendarFrameWidth:
-            #if os(tvOS)
-                let interval = self.direction == .horizontal ? scrollView.frame.width : scrollView.frame.height
-                let calculatedOffset = calculatedCurrentFixedContentOffsetFrom(interval)
-                setTargetContentOffset(calculatedOffset)
-            #endif
-            break
-        case .stopAtEachSection:
-            var calculatedOffSet: CGFloat = 0
-            if self.direction == .horizontal || (self.direction == .vertical && self.registeredHeaderViews.count < 1) {
-                // Horizontal has a fixed width. Vertical with no header has fixed height
-                let interval = calendarLayout.sizeOfContentForSection(theCurrentSection)
-                calculatedOffSet = calculatedCurrentFixedContentOffsetFrom(interval)
-            } else {
-                // Vertical with headers have variable heights. It needs to be calculated
-                let currentScrollOffset = scrollView.contentOffset.y
-                let currentScrollSection = calendarLayout.sectionFromOffset(currentScrollOffset)
-                var sectionSize: CGFloat = 0
+            let isNotScrolling = {
+                return contentOffset == self.lastSavedContentOffset
+            }
+            if isNotScrolling() {
+                return
+            }
+            if directionVelocity == 0.0 {
+                calendarView.decelerationRate =
+                    UIScrollViewDecelerationRateFast
+            }
+
+            let setTargetContentOffset = {
+                (finalOffset: CGFloat) -> Void in
+                if self.direction == .horizontal {
+                    targetContentOffset.pointee.x = finalOffset
+                } else {
+                    targetContentOffset.pointee.y = finalOffset
+                }
+            }
+
+            let calculatedCurrentFixedContentOffsetFrom = {
+                (interval: CGFloat) -> CGFloat in
                 if isScrollingForward() {
-                    sectionSize = calendarLayout.sectionSize[currentScrollSection]
-                    calculatedOffSet = sectionSize
+                    return ceil(contentOffset / interval) * interval
                 } else {
-                    if currentScrollSection - 1  >= 0 {
-                        calculatedOffSet = calendarLayout.sectionSize[currentScrollSection - 1]
-                    }
+                    return floor(contentOffset / interval) * interval
                 }
             }
-            setTargetContentOffset(calculatedOffSet)
-        case .nonStopToSection, .nonStopToCell, .nonStopTo:
-            let diff = abs(theTargetContentOffset - contentOffset)
-            let targetSection = calendarLayout.sectionFromOffset(theTargetContentOffset)
-            var calculatedOffSet = contentOffset
+
+            let recalculateOffset = {
+                (diff: CGFloat, interval: CGFloat) -> CGFloat in
+                if isScrollingForward() {
+                    let recalcOffsetAfterResistanceApplied =
+                        theTargetContentOffset - diff
+                    return ceil(recalcOffsetAfterResistanceApplied /
+                        interval) * interval
+                } else {
+                    let recalcOffsetAfterResistanceApplied =
+                        theTargetContentOffset + diff
+                    return floor(recalcOffsetAfterResistanceApplied /
+                        interval) * interval
+                }
+            }
+
+            let scrollViewShouldStopAtBeginning = {
+                () -> Bool in
+                return contentOffset < 0 && theTargetContentOffset == 0 ?
+                    true : false
+            }
+            let scrollViewShouldStopAtEnd = {
+                (calculatedOffSet: CGFloat) -> Bool in
+                return calculatedOffSet > contentSizeEndOffset
+            }
             switch scrollingMode {
-            case let .nonStopToSection(resistance):
-                let interval = calendarLayout.sizeOfContentForSection(targetSection)
-                let diffResistance = diff * resistance
-                if direction == .horizontal {
-                    calculatedOffSet = recalculateOffset(diffResistance, interval)
-                } else {
-                    if isScrollingForward() {
-                        calculatedOffSet = theTargetContentOffset - diffResistance
-                    } else {
-                        calculatedOffSet = theTargetContentOffset + diffResistance
-                    }
-                    let stopSection = isScrollingForward() ? calendarLayout.sectionFromOffset(calculatedOffSet) : calendarLayout.sectionFromOffset(calculatedOffSet) - 1
-                    calculatedOffSet = stopSection < 0 ? 0 : calendarLayout.sectionSize[stopSection]
-                }
-                setTargetContentOffset(calculatedOffSet)
-            case let .nonStopToCell(resistance):
-                let interval = calendarLayout.cellCache[targetSection]![0].frame.width
-                let diffResistance = diff * resistance
-                if direction == .horizontal {
-                    if scrollViewShouldStopAtBeginning() {
-                        calculatedOffSet = 0
-                    } else if scrollViewShouldStopAtEnd(calculatedOffSet) {
-                        calculatedOffSet = theTargetContentOffset
-                    } else {
-                        calculatedOffSet = recalculateOffset(diffResistance, interval)
-                    }
-                } else {
-                    var stopSection: Int
-                    if isScrollingForward() {
-                        calculatedOffSet =  scrollViewShouldStopAtEnd(calculatedOffSet) ? theTargetContentOffset : theTargetContentOffset - diffResistance
-                        stopSection = calendarLayout.sectionFromOffset(calculatedOffSet)
-                    } else {
-                        calculatedOffSet = scrollViewShouldStopAtBeginning() ? 0 : theTargetContentOffset + diffResistance
-                        stopSection = calendarLayout.sectionFromOffset(calculatedOffSet)
-                    }
-                    if contentOffset > 0, let path = self.calendarView.indexPathForItem(at: CGPoint(x: targetContentOffset.pointee.x, y: calculatedOffSet)) {
-                        let attrib = self.calendarView.layoutAttributesForItem(at: path)!
-                        if isScrollingForward() {
-                            calculatedOffSet = attrib.frame.origin.y + attrib.frame.size.height
-                        } else {
-                            calculatedOffSet = attrib.frame.origin.y
-                        }
-                    } else if registeredHeaderViews.count > 0,
-                            let attrib = self.calendarView.layoutAttributesForSupplementaryElement(ofKind: UICollectionElementKindSectionHeader,
-                                                                                                   at: (IndexPath(item: 0, section: stopSection))) {
-                        // change the final value to the end of the header
-                        if isScrollingForward() {
-                            calculatedOffSet = attrib.frame.origin.y + attrib.frame.size.height
-                        } else {
-                            calculatedOffSet =  stopSection - 1 < 0 ? 0 : calendarLayout.sectionSize[stopSection - 1]
-                        }
-                    }
-                }
-                setTargetContentOffset(calculatedOffSet)
-            case let .nonStopTo(interval, resistance): // Both horizontal and vertical are fixed
-                let diffResistance = diff * resistance
-                calculatedOffSet = recalculateOffset(diffResistance, interval)
-                setTargetContentOffset(calculatedOffSet)
-            default:
+            case let .stopAtEach(customInterval: interval):
+                let calculatedOffset =
+                    calculatedCurrentFixedContentOffsetFrom(interval)
+                setTargetContentOffset(calculatedOffset)
+            case .stopAtEachCalendarFrameWidth:
+                #if os(tvOS)
+                    let interval = self.direction == .horizontal ?
+                        scrollView.frame.width : scrollView.frame.height
+                    let calculatedOffset =
+                        calculatedCurrentFixedContentOffsetFrom(interval)
+                    setTargetContentOffset(calculatedOffset)
+                #endif
                 break
+            case .stopAtEachSection:
+                var calculatedOffSet: CGFloat = 0
+                if self.direction == .horizontal ||
+                    (self.direction == .vertical &&
+                        self.registeredHeaderViews.count < 1) {
+                            // Horizontal has a fixed width.
+                            // Vertical with no header has fixed height
+                            let interval = calendarLayout
+                                .sizeOfContentForSection(theCurrentSection)
+                            calculatedOffSet =
+                                calculatedCurrentFixedContentOffsetFrom(
+                                    interval)
+                } else {
+                    // Vertical with headers have variable heights.
+                    // It needs to be calculated
+                    let currentScrollOffset = scrollView.contentOffset.y
+                    let currentScrollSection =
+                        calendarLayout.sectionFromOffset(currentScrollOffset)
+                    var sectionSize: CGFloat = 0
+                    if isScrollingForward() {
+                        sectionSize = calendarLayout
+                            .sectionSize[currentScrollSection]
+                        calculatedOffSet = sectionSize
+                    } else {
+                        if currentScrollSection - 1  >= 0 {
+                            calculatedOffSet = calendarLayout
+                                .sectionSize[currentScrollSection - 1]
+                        }
+                    }
+                }
+                setTargetContentOffset(calculatedOffSet)
+            case .nonStopToSection, .nonStopToCell, .nonStopTo:
+                let diff = abs(theTargetContentOffset - contentOffset)
+                let targetSection = calendarLayout
+                    .sectionFromOffset(theTargetContentOffset)
+                var calculatedOffSet = contentOffset
+                switch scrollingMode {
+                case let .nonStopToSection(resistance):
+                    let interval = calendarLayout
+                        .sizeOfContentForSection(targetSection)
+                    let diffResistance = diff * resistance
+                    if direction == .horizontal {
+                        calculatedOffSet =
+                            recalculateOffset(diffResistance, interval)
+                    } else {
+                        if isScrollingForward() {
+                            calculatedOffSet =
+                                theTargetContentOffset - diffResistance
+                        } else {
+                            calculatedOffSet =
+                                theTargetContentOffset + diffResistance
+                        }
+                        let stopSection = isScrollingForward() ?
+                            calendarLayout
+                                .sectionFromOffset(calculatedOffSet) :
+                            calendarLayout
+                                .sectionFromOffset(calculatedOffSet) - 1
+                        calculatedOffSet = stopSection < 0 ?
+                            0 : calendarLayout.sectionSize[stopSection]
+                    }
+                    setTargetContentOffset(calculatedOffSet)
+                case let .nonStopToCell(resistance):
+                    let interval = calendarLayout
+                        .cellCache[targetSection]![0].frame.width
+                    let diffResistance = diff * resistance
+                    if direction == .horizontal {
+                        if scrollViewShouldStopAtBeginning() {
+                            calculatedOffSet = 0
+                        } else if
+                            scrollViewShouldStopAtEnd(calculatedOffSet) {
+                                calculatedOffSet = theTargetContentOffset
+                        } else {
+                            calculatedOffSet =
+                                recalculateOffset(diffResistance, interval)
+                        }
+                    } else {
+                        var stopSection: Int
+                        if isScrollingForward() {
+                            calculatedOffSet =
+                                scrollViewShouldStopAtEnd(calculatedOffSet) ?
+                                    theTargetContentOffset :
+                                    theTargetContentOffset - diffResistance
+                            stopSection = calendarLayout
+                                .sectionFromOffset(calculatedOffSet)
+                        } else {
+                            calculatedOffSet =
+                                scrollViewShouldStopAtBeginning() ?
+                                    0 :
+                                    theTargetContentOffset + diffResistance
+                            stopSection = calendarLayout
+                                .sectionFromOffset(calculatedOffSet)
+                        }
+                        let pathPoint = CGPoint(
+                            x: targetContentOffset.pointee.x,
+                            y: calculatedOffSet
+                        )
+                        let attribPath =
+                            IndexPath(item: 0, section: stopSection)
+                        if contentOffset > 0, let path = self
+                            .calendarView.indexPathForItem(at: pathPoint) {
+                                let attrib = self.calendarView
+                                    .layoutAttributesForItem(at: path)!
+                                if isScrollingForward() {
+                                    calculatedOffSet =
+                                        attrib.frame.origin.y +
+                                        attrib.frame.size.height
+                                } else {
+                                    calculatedOffSet = attrib.frame.origin.y
+                                }
+                        } else if registeredHeaderViews.count > 0,
+                            let attrib = self.calendarView
+                                .layoutAttributesForSupplementaryElement(
+                                    ofKind:
+                                        UICollectionElementKindSectionHeader,
+                                    at: attribPath) {
+
+                            // change the final value to the end of the header
+                            if isScrollingForward() {
+                                calculatedOffSet =
+                                    attrib.frame.origin.y +
+                                    attrib.frame.size.height
+                            } else {
+                                calculatedOffSet =
+                                    stopSection - 1 < 0 ?
+                                    0 :
+                                    calendarLayout
+                                        .sectionSize[stopSection - 1]
+                            }
+                        }
+                    }
+                    setTargetContentOffset(calculatedOffSet)
+                case let .nonStopTo(interval, resistance):
+                    // Both horizontal and vertical are fixed
+                    let diffResistance = diff * resistance
+                    calculatedOffSet =
+                        recalculateOffset(diffResistance, interval)
+                    setTargetContentOffset(calculatedOffSet)
+                default:
+                    break
+                }
+            default:
+                // If we go through this route, then no animated scrolling
+                // was done. User scrolled and stopped and lifted finger.
+                // Thus update the label.
+                delayRunOnMainThread(0.0) {
+                    self.scrollViewDidEndDecelerating(self.calendarView)
+                }
             }
-        default:
-            // If we go through this route, then no animated scrolling was done. User scrolled and stopped and lifted finger. Thus update the label.
-            delayRunOnMainThread(0.0) {
-                self.scrollViewDidEndDecelerating(self.calendarView)
+            saveLastContentOffset()
+            delayRunOnMainThread(0.7) {
+                self.calendarView.decelerationRate = cachedDecelerationRate
             }
-        }
-        saveLastContentOffset()
-        delayRunOnMainThread(0.7) {
-            self.calendarView.decelerationRate = cachedDecelerationRate
-        }
     }
-    /// Tells the delegate when a scrolling animation in the scroll view concludes.
-    public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
-        if
-            let shouldTrigger = triggerScrollToDateDelegate,
-            shouldTrigger == true {
-            scrollViewDidEndDecelerating(scrollView)
-            triggerScrollToDateDelegate = nil
-        }
-        executeDelayedTasks()
-        // A scroll was just completed.
-        scrollInProgress = false
+
+    /// Tells the delegate when a scrolling
+    /// animation in the scroll view concludes.
+    public func scrollViewDidEndScrollingAnimation(
+        _ scrollView: UIScrollView) {
+            if
+                let shouldTrigger = triggerScrollToDateDelegate,
+                shouldTrigger == true {
+                scrollViewDidEndDecelerating(scrollView)
+                triggerScrollToDateDelegate = nil
+            }
+            executeDelayedTasks()
+            // A scroll was just completed.
+            scrollInProgress = false
     }
-    /// Tells the delegate that the scroll view has ended decelerating the scrolling movement.
+
+    /// Tells the delegate that the scroll view has
+    /// ended decelerating the scrolling movement.
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let currentSegmentDates = dateSegment()
-        self.delegate?.calendar(self,
-                                didScrollToDateSegmentFor: (start: currentSegmentDates.range.start, end: currentSegmentDates.range.end),
-                                belongingTo: currentSegmentDates.month,
-                                rows: currentSegmentDates.rowsForSection)
+        self.delegate?.calendar(
+            self,
+            didScrollToDateSegmentFor: (
+                start: currentSegmentDates.range.start,
+                end: currentSegmentDates.range.end
+            ),
+            belongingTo: currentSegmentDates.month,
+            rows: currentSegmentDates.rowsForSection
+        )
     }
+
 }

--- a/Sources/UserInteractionFunctions.swift
+++ b/Sources/UserInteractionFunctions.swift
@@ -8,110 +8,193 @@
 
 
 extension JTAppleCalendarView {
-    /// Returns the cellStatus of a date that is visible on the screen. If the row and column for the date cannot be found, then nil is returned
+
+    /// Returns the cellStatus of a date that is visible on the screen.
+    /// If the row and column for the date cannot be found,
+    /// then nil is returned
     /// - Paramater row: Int row of the date to find
     /// - Paramater column: Int column of the date to find
     /// - returns:
     ///     - CellState: The state of the found cell
     public func cellStatusForDate(at row: Int, column: Int) -> CellState? {
         let convertedRow = (row * maxNumberOfDaysInWeek) + column
-        let indexPathToFind = IndexPath(item: convertedRow, section: currentSectionPage)
+        let indexPathToFind =
+            IndexPath(item: convertedRow, section: currentSectionPage)
         if let date = dateInfoFromPath(indexPathToFind) {
-            let stateOfCell = cellStateFromIndexPath(indexPathToFind, withDateInfo: date)
+            let stateOfCell =
+                cellStateFromIndexPath(indexPathToFind, withDateInfo: date)
             return stateOfCell
         }
         return nil
     }
+
     /// Returns the cell status for a given date
     /// - Parameter: date Date of the cell you want to find
     /// - returns:
     ///     - CellState: The state of the found cell
     public func cellStatus(for date: Date) -> CellState? {
         // validate the path
-        let paths = pathsFromDates([date]) // Jt101 change this function to also return information like the dateInfoFromPath function
-        if paths.count < 1 { return nil }
+        let paths = pathsFromDates([date])
+        // Jt101 change this function to also return
+        // information like the dateInfoFromPath function
+        if paths.count < 1 {
+            return nil
+        }
         let cell = calendarView.cellForItem(at: paths[0]) as? JTAppleDayCell
         let stateOfCell = cellStateFromIndexPath(paths[0], cell: cell)
         return stateOfCell
     }
+
     /// Returns the calendar view's current section boundary dates.
     /// - returns:
-    ///     - range: A range containing the startDate and the endDaye for the current date segment
-    ///     - month: The month that the date range belongs to. If you have pre/post dates, this value can be useful to know which month it belongs to.
-    public func dateSegment() -> (range: (start: Date, end: Date), month: Int, rowsForSection: Int) {
-        guard
-            dataSource != nil, let dateSegment = monthInfoFromSection(currentSectionPage) else {
-            if dataSource == nil { print("Error: DataSource not yet set") }
-                return (range: (start: Date(), end: Date()), month: 0, rowsForSection: 0)
+    ///     - range: A range containing the startDate and the
+    ///              endDaye for the current date segment
+    ///     - month: The month that the date range belongs to.
+    ///              If you have pre/post dates, this value can be useful
+    ///              to know which month it belongs to.
+    public func dateSegment() -> (range: (start: Date, end: Date),
+                                  month: Int, rowsForSection: Int) {
+        guard dataSource != nil, let dateSegment =
+            monthInfoFromSection(currentSectionPage) else {
+                if dataSource == nil {
+                    print("Error: DataSource not yet set")
+                }
+                return (range: (start: Date(), end: Date()),
+                        month: 0, rowsForSection: 0)
         }
         return dateSegment
     }
-    /// Let's the calendar know which cell xib to use for the displaying of it's date-cells.
+
+    /// Let's the calendar know which cell xib to
+    /// use for the displaying of it's date-cells.
     /// - Parameter name: The name of the xib of your cell design
-    /// - Parameter bundle: The bundle where the xib can be found. If left nil, the library will search the main bundle
-    public func registerCellViewXib(file name: String, bundle: Bundle? = nil) { cellViewSource = JTAppleCalendarViewSource.fromXib(name, bundle) }
-    /// Let's the calendar know which cell class to use for the displaying of it's date-cells.
+    /// - Parameter bundle: The bundle where the xib can be found.
+    ///                     If left nil, the library will search the
+    ///                     main bundle
+    public func registerCellViewXib(file name: String,
+                                    bundle: Bundle? = nil) {
+        cellViewSource = JTAppleCalendarViewSource.fromXib(name, bundle)
+    }
+
+    /// Let's the calendar know which cell class to use
+    /// for the displaying of it's date-cells.
     /// - Parameter name: The class name of your cell design
-    /// - Parameter bundle: The bundle where the xib can be found. If left nil, the library will search the main bundle
-    public func registerCellViewClass(file name: String, bundle: Bundle? = nil) { cellViewSource = JTAppleCalendarViewSource.fromClassName(name, bundle) }
-    /// Let's the calendar know which cell class to use for the displaying of it's date-cells.
+    /// - Parameter bundle: The bundle where the xib can be found.
+    ///                     If left nil, the library will search the
+    ///                     main bundle
+    public func registerCellViewClass(file name: String,
+                                      bundle: Bundle? = nil) {
+        cellViewSource =
+            JTAppleCalendarViewSource.fromClassName(name, bundle)
+    }
+
+    /// Let's the calendar know which cell
+    /// class to use for the displaying of it's date-cells.
     /// - Parameter name: The type of your cell design
-    public func registerCellViewClass(type: AnyClass) { cellViewSource = JTAppleCalendarViewSource.fromType(type) }
-    /// Register header views with the calender. This needs to be done before the view can be displayed
-    /// - Parameter fileNames: A dictionary containing [headerViewNames:HeaderviewSizes]
-    /// - Parameter bundle: The bundle where the xibs can be found. If left nil, the library will search the main bundle
-    public func registerHeaderView(xibFileNames: [String], bundle: Bundle? = nil) {
-        if xibFileNames.count < 1 { return }
+    public func registerCellViewClass(type: AnyClass) {
+        cellViewSource = JTAppleCalendarViewSource.fromType(type)
+    }
+
+    /// Register header views with the calender. This needs to be done
+    /// before the view can be displayed
+    /// - Parameter fileNames: A dictionary containing
+    ///                        [headerViewNames:HeaderviewSizes]
+    /// - Parameter bundle: The bundle where the xibs can be found.
+    ///                     If left nil, the library will search the
+    ///                     main bundle
+    public func registerHeaderView(xibFileNames: [String],
+                                   bundle: Bundle? = nil) {
+        if xibFileNames.count < 1 {
+        return
+    }
         unregisterHeaders()
         for headerViewXibName in xibFileNames {
-            registeredHeaderViews.append(JTAppleCalendarViewSource.fromXib(headerViewXibName, bundle))
-            self.calendarView.register(JTAppleCollectionReusableView.self,
-                                            forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
-                                            withReuseIdentifier: headerViewXibName)
+            registeredHeaderViews.append(JTAppleCalendarViewSource
+                .fromXib(headerViewXibName, bundle))
+            self.calendarView.register(
+                JTAppleCollectionReusableView.self,
+                forSupplementaryViewOfKind:
+                    UICollectionElementKindSectionHeader,
+                withReuseIdentifier: headerViewXibName
+            )
         }
     }
-    /// Register header views with the calender. This needs to be done before header views can be displayed
-    /// - Parameter fileNames: A dictionary containing [headerViewNames:HeaderviewSizes]
-    /// - Parameter bundle: The bundle where the xibs can be found. If left nil, the library will search the main bundle
-    public func registerHeaderView(classStringNames: [String], bundle: Bundle? = nil) {
-        if classStringNames.count < 1 { return }
+
+    /// Register header views with the calender. This needs to be
+    /// done before header views can be displayed
+    /// - Parameter fileNames: A dictionary containing
+    ///                        [headerViewNames:HeaderviewSizes]
+    /// - Parameter bundle: The bundle where the xibs can be found. If left
+    ///                     nil, the library will search the main bundle
+    public func registerHeaderView(classStringNames: [String],
+                                   bundle: Bundle? = nil) {
+        if classStringNames.count < 1 {
+            return
+        }
         unregisterHeaders()
         for headerViewClassName in classStringNames {
-            registeredHeaderViews.append(JTAppleCalendarViewSource.fromClassName(headerViewClassName, bundle))
-            self.calendarView.register(JTAppleCollectionReusableView.self,
-                                            forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
-                                            withReuseIdentifier: headerViewClassName)
+            registeredHeaderViews.append(JTAppleCalendarViewSource
+                .fromClassName(headerViewClassName, bundle))
+            self.calendarView.register(
+                JTAppleCollectionReusableView.self,
+                forSupplementaryViewOfKind:
+                    UICollectionElementKindSectionHeader,
+                withReuseIdentifier: headerViewClassName
+            )
         }
     }
-    /// Register header views with the calender. This needs to be done before header views can be displayed
-    /// - Parameter fileNames: A dictionary containing [headerViewNames:HeaderviewSizes]
+
+    /// Register header views with the calender. This needs to be done
+    /// before header views can be displayed
+    /// - Parameter fileNames: A dictionary containing
+    ///                        [headerViewNames:HeaderviewSizes]
     public func registerHeaderView(classTypeNames: [AnyClass]) {
-        if classTypeNames.count < 1 { return }
+        if classTypeNames.count < 1 {
+            return
+        }
         unregisterHeaders()
         for aClass in classTypeNames {
-            registeredHeaderViews.append(JTAppleCalendarViewSource.fromType(aClass))
-            self.calendarView.register(JTAppleCollectionReusableView.self,
-                                            forSupplementaryViewOfKind: UICollectionElementKindSectionHeader,
-                                            withReuseIdentifier: aClass.description())
+            registeredHeaderViews
+                .append(JTAppleCalendarViewSource.fromType(aClass))
+            self.calendarView.register(
+                JTAppleCollectionReusableView.self,
+                forSupplementaryViewOfKind:
+                    UICollectionElementKindSectionHeader,
+                    withReuseIdentifier: aClass.description()
+            )
         }
     }
+
     /// Unregister previously registered headers
     public func unregisterHeaders() {
-        registeredHeaderViews.removeAll() // remove the already registered xib files if the user re-registers again.
+        registeredHeaderViews.removeAll()
+        // remove the already registered xib
+        // files if the user re-registers again.
         layoutNeedsUpdating = true
     }
-    /// Reloads the data on the calendar view. Scroll delegates are not triggered with this function.
-    /// - Parameter date: An anchordate that the calendar will scroll to after reload completes
+
+    /// Reloads the data on the calendar view. Scroll delegates are not
+    //  triggered with this function.
+    /// - Parameter date: An anchordate that the calendar will
+    ///                   scroll to after reload completes
     /// - Parameter animation: Scroll is animated if this is set to true
-    /// - Parameter completionHandler: This closure will run after the reload is complete
-    public func reloadData(withAnchor date: Date? = nil, animation: Bool = false, completionHandler: (() -> Void)? = nil) {
+    /// - Parameter completionHandler: This closure will run after
+    ///                                the reload is complete
+    public func reloadData(withAnchor date: Date? = nil,
+                           animation: Bool = false,
+                           completionHandler: (() -> Void)? = nil) {
         if !calendarIsAlreadyLoaded {
             return
         }
-        reloadData(checkDelegateDataSource: true, withAnchorDate: date, withAnimation: animation, completionHandler: completionHandler)
+        reloadData(checkDelegateDataSource: true,
+                   withAnchorDate: date,
+                   withAnimation: animation,
+                   completionHandler: completionHandler)
     }
+
     /// Reload the date of specified date-cells on the calendar-view
-    /// - Parameter dates: Date-cells with these specified dates will be reloaded
+    /// - Parameter dates: Date-cells with these specified
+    ///                    dates will be reloaded
     public func reloadDates(_ dates: [Date]) {
         var paths = [IndexPath]()
         for date in dates {
@@ -119,234 +202,411 @@ extension JTAppleCalendarView {
             paths.append(contentsOf: aPath)
             if aPath.count > 0 {
                 let cellState = cellStateFromIndexPath(aPath[0])
-                if let validCounterPartCell = indexPathOfdateCellCounterPart(date, indexPath: aPath[0], dateOwner: cellState.dateBelongsTo) {
+                if let validCounterPartCell =
+                    indexPathOfdateCellCounterPart(
+                        date,
+                        indexPath: aPath[0],
+                        dateOwner: cellState.dateBelongsTo) {
                     paths.append(validCounterPartCell)
                 }
             }
         }
         batchReloadIndexPaths(paths)
     }
+
     /// Select a date-cell range
     /// - Parameter startDate: Date to start the selection from
     /// - Parameter endDate: Date to end the selection from
-    /// - Parameter triggerDidSelectDelegate: Triggers the delegate function only if the value is set to true.
-    /// Sometimes it is necessary to setup some dates without triggereing the delegate e.g. For instance, when youre initally setting up data in your viewDidLoad
-    /// - Parameter keepSelectionIfMultiSelectionAllowed: This is only applicable in allowedMultiSelection = true.
-    /// This overrides the default toggle behavior of selection. If true, selected cells will remain selected.
-    public func selectDates(from startDate: Date, to endDate: Date, triggerSelectionDelegate: Bool = true, keepSelectionIfMultiSelectionAllowed: Bool = false) {
-        selectDates(generateDateRange(from: startDate, to: endDate),
-                    triggerSelectionDelegate: triggerSelectionDelegate,
-                    keepSelectionIfMultiSelectionAllowed: keepSelectionIfMultiSelectionAllowed)
+    /// - Parameter triggerDidSelectDelegate: Triggers the delegate
+    ///   function only if the value is set to true.
+    /// Sometimes it is necessary to setup some dates without triggereing
+    /// the delegate e.g. For instance, when youre initally setting up data
+    /// in your viewDidLoad
+    /// - Parameter keepSelectionIfMultiSelectionAllowed: This is only
+    ///   applicable in allowedMultiSelection = true.
+    /// This overrides the default toggle behavior of selection.
+    /// If true, selected cells will remain selected.
+    public func selectDates(
+        from startDate: Date, to endDate: Date,
+        triggerSelectionDelegate: Bool = true,
+        keepSelectionIfMultiSelectionAllowed: Bool = false) {
+            selectDates(generateDateRange(from: startDate, to: endDate),
+                        triggerSelectionDelegate: triggerSelectionDelegate,
+                        keepSelectionIfMultiSelectionAllowed:
+                            keepSelectionIfMultiSelectionAllowed)
     }
-    
+
     public func deselectAllDates(triggerSelectionDelegate: Bool = true) {
-        selectDates(selectedDates, triggerSelectionDelegate: triggerSelectionDelegate)
+        selectDates(selectedDates,
+                    triggerSelectionDelegate: triggerSelectionDelegate)
     }
+
     /// Select a date-cells
     /// - Parameter date: The date-cell with this date will be selected
-    /// - Parameter triggerDidSelectDelegate: Triggers the delegate function only if the value is set to true.
-    /// Sometimes it is necessary to setup some dates without triggereing the delegate e.g. For instance, when youre initally setting up data in your viewDidLoad
-    public func selectDates(_ dates: [Date], triggerSelectionDelegate: Bool = true, keepSelectionIfMultiSelectionAllowed: Bool = false) {
-        if !calendarIsAlreadyLoaded { // If the calendar is nnot yet fully loaded. Add the task to the delayed queue
-            delayedExecutionClosure.append({ self.selectDates(dates, triggerSelectionDelegate: triggerSelectionDelegate, keepSelectionIfMultiSelectionAllowed: keepSelectionIfMultiSelectionAllowed)})
-            return
+    /// - Parameter triggerDidSelectDelegate: Triggers the delegate function
+    ///    only if the value is set to true.
+    /// Sometimes it is necessary to setup some dates without triggereing
+    /// the delegate e.g. For instance, when youre initally setting up data
+    /// in your viewDidLoad
+    public func selectDates(
+        _ dates: [Date],
+        triggerSelectionDelegate: Bool = true,
+        keepSelectionIfMultiSelectionAllowed: Bool = false) {
+            if !calendarIsAlreadyLoaded {
+                // If the calendar is nnot yet fully loaded.
+                // Add the task to the delayed queue
+                delayedExecutionClosure.append {
+                    self.selectDates(
+                        dates,
+                        triggerSelectionDelegate: triggerSelectionDelegate,
+                        keepSelectionIfMultiSelectionAllowed:
+                            keepSelectionIfMultiSelectionAllowed
+                    )
+                }
+                return
         }
         var allIndexPathsToReload: [IndexPath] = []
         var validDatesToSelect = dates
-        // If user is trying to select multiple dates with multiselection disabled, then only select the last object
-        if !calendarView.allowsMultipleSelection && dates.count > 0 { validDatesToSelect = [dates.last!] }
-        let addToIndexSetToReload = {(indexPath: IndexPath) -> Void in
-            if !allIndexPathsToReload.contains(indexPath) { allIndexPathsToReload.append(indexPath) } // To avoid adding the  same indexPath twice.
+        // If user is trying to select multiple dates with
+        // multiselection disabled, then only select the last object
+        if !calendarView.allowsMultipleSelection && dates.count > 0 {
+            validDatesToSelect = [dates.last!]
         }
-        let selectTheDate = {(indexPath: IndexPath, date: Date) -> Void in
-            self.calendarView.selectItem(at: indexPath, animated: false, scrollPosition: [])
+        let addToIndexSetToReload = { (indexPath: IndexPath) -> Void in
+            if !allIndexPathsToReload.contains(indexPath) {
+                allIndexPathsToReload.append(indexPath)
+            } // To avoid adding the  same indexPath twice.
+        }
+
+        let selectTheDate = {
+            (indexPath: IndexPath, date: Date) -> Void in
+            self.calendarView.selectItem(at: indexPath,
+                                         animated: false, scrollPosition: [])
             addToIndexSetToReload(indexPath)
-            // If triggereing is enabled, then let their delegate handle the reloading of view, else we will reload the data
+            // If triggereing is enabled, then let their delegate
+            // handle the reloading of view, else we will reload the data
             if triggerSelectionDelegate {
-                self.internalCollectionView(self.calendarView, didSelectItemAtIndexPath: indexPath)
-            } else { // Although we do not want the delegate triggered, we still want counterpart cells to be selected
-                // Because there is no triggering of the delegate, the cell will not be added to selection and it will not be reloaded. We need to do this here
+                self.internalCollectionView(
+                    self.calendarView, didSelectItemAtIndexPath: indexPath)
+            } else {
+                // Although we do not want the delegate triggered, we
+                // still want counterpart cells to be selected
+                // Because there is no triggering of the delegate, the cell
+                // will not be added to selection and it will not be
+                // reloaded. We need to do this here
                 self.addCellToSelectedSetIfUnselected(indexPath, date: date)
-                let cellState = self.cellStateFromIndexPath(indexPath)//, withDateInfo: date)
-                if let aSelectedCounterPartIndexPath = self.selectCounterPartCellIndexPathIfExists(indexPath, date: date, dateOwner: cellState.dateBelongsTo) {
-                    // If there was a counterpart cell then it will also need to be reloaded
-                    addToIndexSetToReload(aSelectedCounterPartIndexPath)
+                let cellState = self.cellStateFromIndexPath(indexPath)
+                // , withDateInfo: date)
+                if let aSelectedCounterPartIndexPath =
+                    self.selectCounterPartCellIndexPathIfExists(
+                        indexPath,
+                        date: date,
+                        dateOwner: cellState.dateBelongsTo) {
+                            // If there was a counterpart cell then
+                            // it will also need to be reloaded
+                            addToIndexSetToReload(
+                                aSelectedCounterPartIndexPath
+                            )
                 }
             }
         }
         let deSelectTheDate = { (oldIndexPath: IndexPath) -> Void in
             addToIndexSetToReload(oldIndexPath)
-            if let index = self.theSelectedIndexPaths.index(of: oldIndexPath) {
-                let oldDate = self.theSelectedDates[index]
-                self.calendarView.deselectItem(at: oldIndexPath, animated: false)
-                self.theSelectedIndexPaths.remove(at: index)
-                self.theSelectedDates.remove(at: index)
-                // If delegate triggering is enabled, let the delegate function handle the cell
-                if triggerSelectionDelegate {
-                    self.internalCollectionView(self.calendarView, didDeselectItemAtIndexPath: oldIndexPath)
-                } else { // Although we do not want the delegate triggered, we still want counterpart cells to be deselected
-                    let cellState = self.cellStateFromIndexPath(oldIndexPath)//, withDateInfo: oldDate)
-                    if let anUnselectedCounterPartIndexPath = self.deselectCounterPartCellIndexPath(oldIndexPath, date: oldDate, dateOwner: cellState.dateBelongsTo) {
-                        // If there was a counterpart cell then it will also need to be reloaded
-                        addToIndexSetToReload(anUnselectedCounterPartIndexPath)
+            if let index = self.theSelectedIndexPaths
+                .index(of: oldIndexPath) {
+                    let oldDate = self.theSelectedDates[index]
+                    self.calendarView.deselectItem(at: oldIndexPath,
+                                                   animated: false)
+                    self.theSelectedIndexPaths.remove(at: index)
+                    self.theSelectedDates.remove(at: index)
+                    // If delegate triggering is enabled, let the
+                    // delegate function handle the cell
+                    if triggerSelectionDelegate {
+                        self.internalCollectionView(self.calendarView,
+                            didDeselectItemAtIndexPath: oldIndexPath)
+                    } else {
+                        // Although we do not want the delegate triggered,
+                        // we still want counterpart cells to be deselected
+                        let cellState =
+                            self.cellStateFromIndexPath(oldIndexPath)
+                                // , withDateInfo: oldDate)
+                        if let anUnselectedCounterPartIndexPath =
+                            self.deselectCounterPartCellIndexPath(
+                                oldIndexPath, date: oldDate,
+                                dateOwner: cellState.dateBelongsTo) {
+                                    // If there was a counterpart cell then
+                                    // it will also need to be reloaded
+                                    addToIndexSetToReload(
+                                        anUnselectedCounterPartIndexPath
+                                    )
+                        }
                     }
-                }
             }
         }
         for date in validDatesToSelect {
-            let components = self.calendar.dateComponents([.year, .month, .day], from: date)
+            let components = self.calendar
+                .dateComponents([.year, .month, .day], from: date)
             let firstDayOfDate = self.calendar.date(from: components)!
             // If the date is not within valid boundaries, then exit
-            if !(firstDayOfDate >= self.startOfMonthCache && firstDayOfDate <= self.endOfMonthCache) { continue }
+            if !(firstDayOfDate >= self.startOfMonthCache &&
+                firstDayOfDate <= self.endOfMonthCache) {
+                    continue
+            }
             let pathFromDates = self.pathsFromDates([date])
-            // If the date path youre searching for, doesnt exist, then return
-            if pathFromDates.count < 0 { continue }
+            // If the date path youre searching for, doesnt exist, return
+            if pathFromDates.count < 0 {
+                continue
+            }
             let sectionIndexPath = pathFromDates[0]
             // Remove old selections
-            if self.calendarView.allowsMultipleSelection == false { // If single selection is ON
-                let selectedIndexPaths = self.theSelectedIndexPaths // made a copy because the array is about to be mutated
+            if self.calendarView.allowsMultipleSelection == false {
+                // If single selection is ON
+                let selectedIndexPaths = self.theSelectedIndexPaths
+                // made a copy because the array is about to be mutated
                 for indexPath in selectedIndexPaths {
-                    if indexPath != sectionIndexPath { deSelectTheDate(indexPath) }
-                }
-                // Add new selections
-                // Must be added here. If added in delegate didSelectItemAtIndexPath
-                selectTheDate(sectionIndexPath, date)
-            } else {
-                // If multiple selection is on. Multiple selection behaves differently to singleselection.
-                // It behaves like a toggle. unless keepSelectionIfMultiSelectionAllowed is true.
-                // If user wants to force selection if multiselection is enabled, then removed the selected dates from generated dates
-                if keepSelectionIfMultiSelectionAllowed {
-                    if selectedDates.contains(calendar.startOfDay(for: date)) {
-                        addToIndexSetToReload(sectionIndexPath)
-                        continue // Do not deselect or select the cell. Just add it to be reloaded
+                    if indexPath != sectionIndexPath {
+                        deSelectTheDate(indexPath)
                     }
                 }
-                if self.theSelectedIndexPaths.contains(sectionIndexPath) { // If this cell is already selected, then deselect it
+                // Add new selections
+                // Must be added here. If added in delegate
+                // didSelectItemAtIndexPath
+                selectTheDate(sectionIndexPath, date)
+            } else {
+                // If multiple selection is on. Multiple selection behaves
+                // differently to singleselection.
+                // It behaves like a toggle. unless
+                // keepSelectionIfMultiSelectionAllowed is true.
+                // If user wants to force selection if multiselection
+                // is enabled, then removed the selected dates from
+                // generated dates
+                if keepSelectionIfMultiSelectionAllowed {
+                    if selectedDates.contains(
+                        calendar.startOfDay(for: date)) {
+                            addToIndexSetToReload(sectionIndexPath)
+                            continue
+                            // Do not deselect or select the cell.
+                            // Just add it to be reloaded
+                    }
+                }
+                if self.theSelectedIndexPaths.contains(sectionIndexPath) {
+                    // If this cell is already selected, then deselect it
                     deSelectTheDate(sectionIndexPath)
                 } else {
                     // Add new selections
-                    // Must be added here. If added in delegate didSelectItemAtIndexPath
+                    // Must be added here. If added in delegate
+                    // didSelectItemAtIndexPath
                     selectTheDate(sectionIndexPath, date)
                 }
             }
         }
-        // If triggering was false, although the selectDelegates weren't called, we do want the cell refreshed. Reload to call itemAtIndexPath
-        if triggerSelectionDelegate == false && allIndexPathsToReload.count > 0 {
-            delayRunOnMainThread(0.0) {
-                self.batchReloadIndexPaths(allIndexPathsToReload)
+        // If triggering was false, although the selectDelegates weren't
+        // called, we do want the cell refreshed.
+        // Reload to call itemAtIndexPath
+        if triggerSelectionDelegate == false &&
+            allIndexPathsToReload.count > 0 {
+                delayRunOnMainThread(0.0) {
+                    self.batchReloadIndexPaths(allIndexPathsToReload)
+                }
+        }
+    }
+
+    /// Scrolls the calendar view to the next section view. It will
+    // execute a completion handler at the end of scroll animation
+    // if provided.
+    /// - Paramater animateScroll: Bool indicating if animation
+    ///   should be enabled
+    /// - Parameter triggerScrollToDateDelegate:
+    ///   Trigger delegate if set to true
+    /// - Parameter completionHandler: A completion handler that
+    ///   will be executed at the end of the scroll animation
+    public func scrollToNextSegment(
+        _ triggerScrollToDateDelegate: Bool = false,
+        animateScroll: Bool = true,
+        completionHandler: (() -> Void)? = nil) {
+            let page = currentSectionPage + 1
+            if page < monthInfo.count {
+                scrollToSection(
+                    page,
+                    triggerScrollToDateDelegate: triggerScrollToDateDelegate,
+                    animateScroll: animateScroll,
+                    completionHandler: completionHandler
+                )
             }
-        }
     }
-    /// Scrolls the calendar view to the next section view. It will execute a completion handler at the end of scroll animation if provided.
-    /// - Paramater animateScroll: Bool indicating if animation should be enabled
-    /// - Parameter triggerScrollToDateDelegate: Trigger delegate if set to true
-    /// - Parameter completionHandler: A completion handler that will be executed at the end of the scroll animation
-    public func scrollToNextSegment(_ triggerScrollToDateDelegate: Bool = false, animateScroll: Bool = true, completionHandler:(() -> Void)? = nil) {
-        let page = currentSectionPage + 1
-        if page < monthInfo.count {
-            scrollToSection(page, triggerScrollToDateDelegate: triggerScrollToDateDelegate, animateScroll: animateScroll, completionHandler: completionHandler)
-        }
+
+    /// Scrolls the calendar view to the previous section view. It will
+    /// execute a completion handler at the end of scroll animation if
+    /// provided.
+    /// - Parameter triggerScrollToDateDelegate: Trigger delegate if set
+    ///   to true
+    /// - Paramater animateScroll: Bool indicating if animation should
+    ///   be enabled
+    /// - Parameter completionHandler: A completion handler that will be
+    ///   executed at the end of the scroll animation
+    public func scrollToPreviousSegment(
+        _ triggerScrollToDateDelegate: Bool = false,
+        animateScroll: Bool = true,
+        completionHandler: (() -> Void)? = nil) {
+            let page = currentSectionPage - 1
+            if page > -1 {
+                scrollToSection(
+                    page,
+                    triggerScrollToDateDelegate: triggerScrollToDateDelegate,
+                    animateScroll: animateScroll,
+                    completionHandler: completionHandler
+                )
+            }
     }
-    /// Scrolls the calendar view to the previous section view. It will execute a completion handler at the end of scroll animation if provided.
-    /// - Parameter triggerScrollToDateDelegate: Trigger delegate if set to true
-    /// - Paramater animateScroll: Bool indicating if animation should be enabled
-    /// - Parameter completionHandler: A completion handler that will be executed at the end of the scroll animation
-    public func scrollToPreviousSegment(_ triggerScrollToDateDelegate: Bool = false, animateScroll: Bool = true, completionHandler:(() -> Void)? = nil) {
-        let page = currentSectionPage - 1
-        if page > -1 {
-            scrollToSection(page, triggerScrollToDateDelegate: triggerScrollToDateDelegate, animateScroll: animateScroll, completionHandler: completionHandler)
+
+    /// Scrolls the calendar view to the start of a section view containing
+    /// a specified date.
+    /// - Paramater date: The calendar view will scroll to a date-cell
+    ///   containing this date if it exists
+    /// - Parameter triggerScrollToDateDelegate: Trigger delegate if set to
+    ///   true
+    /// - Paramater animateScroll: Bool indicating if animation should be
+    ///   enabled
+    /// - Paramater preferredScrollPositionIndex: Integer indicating the end
+    ///   scroll position on the screen.
+    /// This value indicates column number for Horizontal scrolling and row
+    /// number for a vertical scrolling calendar
+    /// - Parameter completionHandler: A completion handler that will be
+    ///   executed at the end of the scroll animation
+    public func scrollToDate(
+        _ date: Date,
+        triggerScrollToDateDelegate: Bool = true,
+        animateScroll: Bool = true,
+        preferredScrollPosition: UICollectionViewScrollPosition? = nil,
+        completionHandler: (() -> Void)? = nil) {
+            if !calendarIsAlreadyLoaded {
+                delayedExecutionClosure.append {
+                    self.scrollToDate(
+                        date,
+                        triggerScrollToDateDelegate:
+                            triggerScrollToDateDelegate,
+                        animateScroll: animateScroll,
+                        preferredScrollPosition: preferredScrollPosition,
+                        completionHandler: completionHandler)
+                }
+                return
         }
-    }
-    /// Scrolls the calendar view to the start of a section view containing a specified date.
-    /// - Paramater date: The calendar view will scroll to a date-cell containing this date if it exists
-    /// - Parameter triggerScrollToDateDelegate: Trigger delegate if set to true
-    /// - Paramater animateScroll: Bool indicating if animation should be enabled
-    /// - Paramater preferredScrollPositionIndex: Integer indicating the end scroll position on the screen.
-    /// This value indicates column number for Horizontal scrolling and row number for a vertical scrolling calendar
-    /// - Parameter completionHandler: A completion handler that will be executed at the end of the scroll animation
-    public func scrollToDate(_ date: Date,
-                             triggerScrollToDateDelegate: Bool = true,
-                             animateScroll: Bool = true,
-                             preferredScrollPosition: UICollectionViewScrollPosition? = nil,
-                             completionHandler:(() -> Void)? = nil) {
-        if !calendarIsAlreadyLoaded {
-            delayedExecutionClosure.append({ self.scrollToDate(date,
-                                                               triggerScrollToDateDelegate: triggerScrollToDateDelegate,
-                                                               animateScroll: animateScroll,
-                                                               preferredScrollPosition: preferredScrollPosition,
-                                                               completionHandler: completionHandler) })
-            return
-        }
-        
+
         self.triggerScrollToDateDelegate = triggerScrollToDateDelegate
-        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        let components =
+            calendar.dateComponents([.year, .month, .day], from: date)
         let firstDayOfDate = calendar.date(from: components)!
         scrollInProgress = true
         delayRunOnMainThread(0.0, closure: {
             // This part should be inside the mainRunLoop
-            if !(firstDayOfDate >= self.startOfMonthCache && firstDayOfDate <= self.endOfMonthCache) {
-                self.scrollInProgress = false
-                return
+            if !(firstDayOfDate >= self.startOfMonthCache &&
+                firstDayOfDate <= self.endOfMonthCache) {
+                    self.scrollInProgress = false
+                    return
             }
             let retrievedPathsFromDates = self.pathsFromDates([date])
             if retrievedPathsFromDates.count > 0 {
                 let sectionIndexPath =  self.pathsFromDates([date])[0]
-                var position: UICollectionViewScrollPosition = self.direction == .horizontal ? .left : .top
+                var position: UICollectionViewScrollPosition =
+                    self.direction == .horizontal ? .left : .top
                 if !self.scrollingMode.pagingIsEnabled() {
-                    if let validPosition: UICollectionViewScrollPosition = preferredScrollPosition {
+                    if let validPosition = preferredScrollPosition {
                         if self.direction == .horizontal {
-                            if validPosition == .left || validPosition == .right || validPosition == .centeredHorizontally {
-                                position = validPosition
+                            if validPosition == .left ||
+                                validPosition == .right ||
+                                validPosition == .centeredHorizontally {
+                                    position = validPosition
                             } else {
                                 position = .left
                             }
                         } else {
-                            if validPosition == .top || validPosition == .bottom || validPosition == .centeredVertically {
-                                position = validPosition
+                            if validPosition == .top ||
+                                validPosition == .bottom ||
+                                validPosition == .centeredVertically {
+                                    position = validPosition
                             } else {
                                 position = .top
                             }
                         }
                     }
                 }
-                let scrollToIndexPath = {(iPath: IndexPath, withAnimation: Bool) -> Void in
-                    if let validCompletionHandler = completionHandler { self.delayedExecutionClosure.append(validCompletionHandler) }
+                let scrollToIndexPath = {
+                    (iPath: IndexPath, withAnimation: Bool) -> Void in
+                    if let validCompletionHandler = completionHandler {
+                        self.delayedExecutionClosure
+                            .append(validCompletionHandler)
+                    }
                     // regular movement
-                    self.calendarView.scrollToItem(at: iPath, at: position, animated: animateScroll)
+                    self.calendarView.scrollToItem(at: iPath,
+                                                   at: position,
+                                                   animated: animateScroll)
                     if animateScroll {
-                        if let check = self.calendarOffsetIsAlreadyAtScrollPosition(forIndexPath: iPath), check == true {
-                                self.scrollViewDidEndScrollingAnimation(self.calendarView)
-                                self.scrollInProgress = false
-                                return
+                        if let check = self
+                            .calendarOffsetIsAlreadyAtScrollPosition(
+                                forIndexPath: iPath), check == true {
+                                    self.scrollViewDidEndScrollingAnimation(
+                                        self.calendarView
+                                    )
+                                    self.scrollInProgress = false
+                                    return
                         }
                     }
                 }
                 if self.scrollingMode.pagingIsEnabled() {
                     if self.registeredHeaderViews.count > 0 {
-                        // If both paging and header is on, then scroll to the actual date
-                        // If direction is vertical and user has a custom size that is at least the size of the collectionview.
-                        // If this check is not done, it will scroll to header, and have white space at bottom because view is smaller due to small custom user itemSize
-                        if self.direction == .vertical && self.calendarViewLayout.sizeOfSection(sectionIndexPath.section) >= self.calendarView.frame.height {
-                            self.scrollToHeaderInSection(sectionIndexPath.section,
-                                                         triggerScrollToDateDelegate: triggerScrollToDateDelegate,
-                                                         withAnimation: animateScroll,
-                                                         completionHandler: completionHandler)
+                        // If both paging and header is on, then scroll to
+                        // the actual date
+                        // If direction is vertical and user has a custom
+                        // size that is at least the size of the
+                        // collectionview.
+                        // If this check is not done, it will scroll to
+                        // header, and have white space at bottom because
+                        // view is smaller due to small custom user itemSize
+                        if self.direction == .vertical &&
+                            self.calendarViewLayout
+                                .sizeOfSection(sectionIndexPath.section) >=
+                                    self.calendarView.frame.height {
+
+                            self.scrollToHeaderInSection(
+                                sectionIndexPath.section,
+                                triggerScrollToDateDelegate:
+                                    triggerScrollToDateDelegate,
+                                withAnimation: animateScroll,
+                                completionHandler: completionHandler
+                            )
                             return
                         } else {
-                            scrollToIndexPath(IndexPath(item: 0, section: sectionIndexPath.section), animateScroll)
+                            scrollToIndexPath(
+                                IndexPath(
+                                    item: 0,
+                                    section: sectionIndexPath.section
+                                ),
+                                animateScroll
+                            )
                         }
                     } else {
-                        // If paging is on and header is off, then scroll to the start date in section
-                        scrollToIndexPath(IndexPath(item: 0, section: sectionIndexPath.section), animateScroll)
+                        // If paging is on and header is off,
+                        // then scroll to the start date in section
+                        scrollToIndexPath(
+                            IndexPath(
+                                item: 0,
+                                section: sectionIndexPath.section
+                            ),
+                            animateScroll
+                        )
                     }
                 } else {
-                    // If paging is off, then scroll to the actual date in the section
+                    // If paging is off, then scroll to the
+                    // actual date in the section
                     scrollToIndexPath(sectionIndexPath, animateScroll)
                 }
-                // Jt101 put this into a function to reduce code between this and the scroll to header function
+                // Jt101 put this into a function to reduce code between
+                // this and the scroll to header function
                 delayRunOnMainThread(0.0, closure: {
                     if  !animateScroll {
-                        self.scrollViewDidEndScrollingAnimation(self.calendarView)
+                        self.scrollViewDidEndScrollingAnimation(
+                            self.calendarView
+                        )
                         self.scrollInProgress = false
                     }
                 })
@@ -355,27 +615,49 @@ extension JTAppleCalendarView {
             }
         })
     }
-    /// Scrolls the calendar view to the start of a section view header. If the calendar has no headers registered, then this function does nothing
-    /// - Paramater date: The calendar view will scroll to the header of a this provided date
-    public func scrollToHeaderForDate(_ date: Date, triggerScrollToDateDelegate: Bool = false, withAnimation animation: Bool = false, completionHandler: (() -> Void)? = nil) {
-        let path = pathsFromDates([date])
-        // Return if date was incalid and no path was returned
-        if path.count < 1 { return }
-        scrollToHeaderInSection(path[0].section, triggerScrollToDateDelegate: triggerScrollToDateDelegate, withAnimation: animation, completionHandler: completionHandler)
+
+    /// Scrolls the calendar view to the start of a section view header.
+    // If the calendar has no headers registered, then this function does
+    // nothing
+    /// - Paramater date: The calendar view will scroll to the header of
+    // a this provided date
+    public func scrollToHeaderForDate(
+        _ date: Date, triggerScrollToDateDelegate: Bool = false,
+        withAnimation animation: Bool = false,
+        completionHandler: (() -> Void)? = nil) {
+            let path = pathsFromDates([date])
+            // Return if date was incalid and no path was returned
+            if path.count < 1 {
+                return
+            }
+            scrollToHeaderInSection(
+                path[0].section,
+                triggerScrollToDateDelegate: triggerScrollToDateDelegate,
+                withAnimation: animation,
+                completionHandler: completionHandler
+        )
     }
-    /// Generates a range of dates from from a startDate to an endDate you provide
+
+    /// Generates a range of dates from from a startDate to an
+    /// endDate you provide
     /// Parameter startDate: Start date to generate dates from
     /// Parameter endDate: End date to generate dates to
     /// returns:
     ///     - An array of the successfully generated dates
-    public func generateDateRange(from startDate: Date, to endDate: Date) -> [Date] {
-        if startDate > endDate { return [] }
+
+    public func generateDateRange(from startDate: Date,
+                                  to endDate: Date) -> [Date] {
+        if startDate > endDate {
+            return []
+        }
         var returnDates: [Date] = []
         var currentDate = startDate
         repeat {
             returnDates.append(currentDate)
-            currentDate = calendar.startOfDay(for: calendar.date(byAdding: .day, value: 1, to: currentDate)!)
+            currentDate = calendar.startOfDay(for: calendar.date(
+                byAdding: .day, value: 1, to: currentDate)!)
         } while currentDate <= endDate
         return returnDates
     }
+
 }

--- a/Tests/JTAppleCalendar_iOSTests.swift
+++ b/Tests/JTAppleCalendar_iOSTests.swift
@@ -6,90 +6,113 @@
 //
 //
 
-import XCTest
-@testable import JTAppleCalendar
-
-//class JTAppleCalendar_iOSTests: XCTestCase, JTAppleCalendarViewDataSource {
+// import XCTest
+// @testable import JTAppleCalendar
+//
+// class JTAppleCalendar_iOSTests: XCTestCase, JTAppleCalendarViewDataSource {
 //    let calendarView = JTAppleCalendarView()
 //    let formatter = NSDateFormatter()
-//    let calendar = NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)
+//    let calendar =
+//        NSCalendar(calendarIdentifier: NSCalendarIdentifierGregorian)
 //    var numberOfRows = 6
 //    var firstDate: Date!
 //    var secondDate: Date!
-//    var returnConfiguration: (startDate: Date, endDate: Date, numberOfRows: Int, calendar: Calendar, generateInDates: Bool, generateOutDates: OutDateCellGeneration)?
+//    var returnConfiguration: (startDate: Date, endDate: Date,
+//                              numberOfRows: Int, calendar: Calendar,
+//                              generateInDates: Bool,
+//                              generateOutDates: OutDateCellGeneration)?
 //    override func setUp() {
 //        super.setUp()
 //        formatter.dateFormat = "yyyy MM dd"
 //    }
 //    override func tearDown() {
-//        // Put teardown code here. This method is called after the invocation of each test method in the class.
+//        // Put teardown code here. This method is called after the
+//        // invocation of each test method in the class.
 //        super.tearDown()
 //    }
 //    func testCheckingCalendarGeneratedData() {
-//        print("Testing to see if setupMonthInfoDataForStartAndEndDate() gives valid month data even when number of rows change")
+//        print("Testing to see if setupMonthInfoDataForStartAndEndDate() " +
+//            "gives valid month data even when number of rows change")
 //        firstDate = formatter.dateFromString("2016 02 01")!
 //        secondDate = formatter.dateFromString("2016 04 01")!
-//        returnConfiguration =
-//(startDate: firstDate, endDate: secondDate, numberOfRows: numberOfRows, calendar: calendar!, generateInDates: false, generateOutDates: .tillEndOfGrid)
+//        returnConfiguration = (startDate: firstDate, endDate: secondDate,
+//                               numberOfRows: numberOfRows,
+//                               calendar: calendar!, generateInDates: false,
+//                               generateOutDates: .tillEndOfGrid)
 //        calendarView.dataSource = self
 //        let monthData = calendarView.setupMonthInfoDataForStartAndEndDate()
 //        print(monthData)
-////        var months: [month]
-////        var totalSections: Int
-////        var monthMap: [Int:Int]
-////        var totalDays: Int
-//        XCTAssert(monthData.months.count == 3, "Verifying if there are 3 months")
-//        XCTAssert(monthData.totalDays == 126, "Verifying number of generated cells")
-//        XCTAssert(monthData.totalSections == 3, "Verifying number of total sections")
+// //        var months: [month]
+// //        var totalSections: Int
+// //        var monthMap: [Int:Int]
+// //        var totalDays: Int
+//        XCTAssert(monthData.months.count == 3,
+//                  "Verifying if there are 3 months")
+//        XCTAssert(monthData.totalDays == 126,
+//                  "Verifying number of generated cells")
+//        XCTAssert(monthData.totalSections == 3,
+//                  "Verifying number of total sections")
 //    }
-////    func test() {
-////    }
-////    func testSegmentFunction() {
-////        print("Testing to see if degment function returns valid data")
-////        firstDate = "2016 01 01"
-////        secondDate = "2016 01 01"
-////        numberOfRows = 6
-////        calendarView.dataSource = self
-////        calendarView.reloadData()
-////        let date = formatter.dateFromString("2016 01 01")!
-////        var month = calendarView.dateFromSection(0)!.month
-////        var compMonth = calendar!.component(.Month, fromDate: date)
-////        XCTAssert(month == compMonth)
-////        numberOfRows = 3
-////        calendarView.reloadData()
-////        for index in 0...1 {
-////            month = calendarView.dateFromSection(index)!.month
-////            compMonth = calendar!.component(.Month, fromDate: date)
-////            XCTAssert(month == compMonth)
-////        }
-////        numberOfRows = 2
-////        calendarView.reloadData()
-////        for index in 0...2 {
-////            month = calendarView.dateFromSection(index)!.month
-////            compMonth = calendar!.component(.Month, fromDate: date)
-////            XCTAssert(month == compMonth)
-////        }
-////        numberOfRows = 1
-////        calendarView.reloadData()
-////        for index in 0...5 {
-////            month = calendarView.dateFromSection(index)!.month
-////            compMonth = calendar!.component(.Month, fromDate: date)
-////            XCTAssert(month == compMonth)
-////        }
-////    }
-////    func testChangeRowToOne() {
-////        // This is an example of a performance test case.
-//////        self.measureBlock {
-////            // Put the code you want to measure the time of here.
-//////        }
-////    }
+// //    func test() {
+// //    }
+// //    func testSegmentFunction() {
+// //        print("Testing to see if degment function returns valid data")
+// //        firstDate = "2016 01 01"
+// //        secondDate = "2016 01 01"
+// //        numberOfRows = 6
+// //        calendarView.dataSource = self
+// //        calendarView.reloadData()
+// //        let date = formatter.dateFromString("2016 01 01")!
+// //        var month = calendarView.dateFromSection(0)!.month
+// //        var compMonth = calendar!.component(.Month, fromDate: date)
+// //        XCTAssert(month == compMonth)
+// //        numberOfRows = 3
+// //        calendarView.reloadData()
+// //        for index in 0...1 {
+// //            month = calendarView.dateFromSection(index)!.month
+// //            compMonth = calendar!.component(.Month, fromDate: date)
+// //            XCTAssert(month == compMonth)
+// //        }
+// //        numberOfRows = 2
+// //        calendarView.reloadData()
+// //        for index in 0...2 {
+// //            month = calendarView.dateFromSection(index)!.month
+// //            compMonth = calendar!.component(.Month, fromDate: date)
+// //            XCTAssert(month == compMonth)
+// //        }
+// //        numberOfRows = 1
+// //        calendarView.reloadData()
+// //        for index in 0...5 {
+// //            month = calendarView.dateFromSection(index)!.month
+// //            compMonth = calendar!.component(.Month, fromDate: date)
+// //            XCTAssert(month == compMonth)
+// //        }
+// //    }
+// //    func testChangeRowToOne() {
+// //        // This is an example of a performance test case.
+// /// /        self.measureBlock {
+// //            // Put the code you want to measure the time of here.
+// /// /        }
+// //    }
 //    func configureCalendar(calendar: JTAppleCalendarView) ->
-//(startDate: Date, endDate: Date, numberOfRows: Int, calendar: Calendar, generateInDates: Bool, generateOutDates: OutDateCellGeneration) {
-//        return returnConfiguration!
-//return (startDate: firstDate!, endDate: secondDate, numberOfRows: numberOfRows, calendar: aCalendar, generateInDates: false, generateOutDates: .tillEndOfRow)
-//return (startDate: firstDate!, endDate: secondDate, numberOfRows: numberOfRows, calendar: aCalendar, generateInDates: false, generateOutDates: .off)
-//return (startDate: firstDate!, endDate: secondDate, numberOfRows: numberOfRows, calendar: aCalendar, generateInDates: true, generateOutDates: .tillEndOfGrid)
-//return (startDate: firstDate!, endDate: secondDate, numberOfRows: numberOfRows, calendar: aCalendar, generateInDates: true, generateOutDates: .off)
-//return (startDate: firstDate!, endDate: secondDate, numberOfRows: numberOfRows, calendar: aCalendar, generateInDates: true, generateOutDates: .off)
+//        (startDate: Date, endDate: Date, numberOfRows: Int,
+//        calendar: Calendar, generateInDates: Bool,
+//        generateOutDates: OutDateCellGeneration) {
+//            return returnConfiguration!
+//            return (startDate: firstDate!, endDate: secondDate,
+//                    numberOfRows: numberOfRows, calendar: aCalendar,
+//                    generateInDates: false, generateOutDates: .tillEndOfRow)
+//            return (startDate: firstDate!, endDate: secondDate,
+//                    numberOfRows: numberOfRows, calendar: aCalendar,
+//                    generateInDates: false, generateOutDates: .off)
+//            return (startDate: firstDate!, endDate: secondDate,
+//                    numberOfRows: numberOfRows, calendar: aCalendar,
+//                    generateInDates: true, generateOutDates: .tillEndOfGrid)
+//            return (startDate: firstDate!, endDate: secondDate,
+//                    numberOfRows: numberOfRows, calendar: aCalendar,
+//                    generateInDates: true, generateOutDates: .off)
+//            return (startDate: firstDate!, endDate: secondDate,
+//                    numberOfRows: numberOfRows, calendar: aCalendar,
+//                    generateInDates: true, generateOutDates: .off)
 //    }
-//}
+// }

--- a/Tests/JTAppleCalendar_tvOSTests.swift
+++ b/Tests/JTAppleCalendar_tvOSTests.swift
@@ -8,18 +8,21 @@
 
 import XCTest
 
-//class JTAppleCalendar_tvOSTests: XCTestCase {
+// class JTAppleCalendar_tvOSTests: XCTestCase {
 //    override func setUp() {
 //        super.setUp()
-//        // Put setup code here. This method is called before the invocation of each test method in the class.
+//        // Put setup code here. This method is called before the
+//        // invocation of each test method in the class.
 //    }
 //    override func tearDown() {
-//        // Put teardown code here. This method is called after the invocation of each test method in the class.
+//        // Put teardown code here. This method is called after the
+//        // invocation of each test method in the class.
 //        super.tearDown()
 //    }
 //    func testExample() {
 //        // This is an example of a functional test case.
-//        // Use XCTAssert and related functions to verify your tests produce the correct results.
+//        // Use XCTAssert and related functions to verify your tests
+//        // produce the correct results.
 //    }
 //    func testPerformanceExample() {
 //        // This is an example of a performance test case.
@@ -27,4 +30,4 @@ import XCTest
 //            // Put the code you want to measure the time of here.
 //        }
 //    }
-//}
+// }


### PR DESCRIPTION
Phew! That was a lot of work.

I used Tailor because swiftlint doesn't support Swift 3 yet. All you have to do is `brew install tailor` and you'll get Tailor's warnings after Xcode builds.

For now I just used the basic rules and the line length rule set to 78 characters.

I broke the lines so that they remain within that limit, but although that makes most of the code a lot more readable, there are a few edge cases where it looks pretty bad. I think it's still a good idea to constrain it to 78 characters, though (you can set a guide column at Xcode's preferences, it's really useful). Most of the problems happen when the code is too indented, so there's very little workable space. And, well, that just shouldn't happen. If the code is shifted to the right so much that you can't fit a single method name, that code needs refactoring. That's a lot more work, though, and we should do it little by little, so for now I just broke the lines. It gets pretty obvious where it needs changes, which is good. When we find a [pyramid of doom](https://en.wikipedia.org/wiki/Pyramid_of_doom_(programming)) we should think about how to refactor that code so that doesn't happen.

I also didn't add many other rules yet, like the function length rule, I think that should be the next one. It's related to the last problem and it would require a lot of refactoring too. There are functions in the code that are more than 100 lines long, that can't happen, we have to split them in more specific functions. Now that I'm getting more familiar with your code I can help little by little.

There's also the name length rule, I think we should restrain construct's names to something like 30 characters, which is already a lot, but there are many functions and variables that go beyond that. Stuff like `setupMonthInfoDataForStartAndEndDate`… which could be something like `setupMonthData(for startDate: Date, endDate: Date…`. Maybe I'm missing something, but why cram all that in `DateConfigParameters`? At first glance it just seems to make things less intuitive, I looked at that and thought "DateConfigParameters? What the hell is that?". While `setupMonthData(for startDate: Date` is a lot friendlier. Anyway, that's just an example, and I can help with all that if you want me to, I just didn't want to start changing everything without even discussing. I didn't even really look at how most of the code works, these are just a few impressions, but maybe there are reasons for things being as they are. So far my changes were mostly just in the style. By the way, it's probably still not perfect, there were a lot of things to change and I have to go to bed, haha. But I'll keep working on it.

And, well, there are other rules and best practices we can implement little by little, that's enough for now I guess, haha.

I tested these changes in the demo app for a bit and everything seems good, but still you should try it out too just to make sure. I don't know what's the future of this `DynamicGeneration` branch, but we should have a sort of a scratch branch just to test stuff before merging with the rest.
