### PR TITLE
Revert "Rename UIScrollViewDelegate methods"

### DIFF
--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -532,7 +532,7 @@ open class JTAppleCalendarView: UIView {
                 self.calendarView.setContentOffset(topOfHeader,
                                                    animated: animation)
                 if  !animation {
-                    self.didEndScrollAnimation(self.calendarView)
+                    self.scrollViewDidEndScrollingAnimation(self.calendarView)
                     self.scrollInProgress = false
                 } else {
                     // If the scroll is set to animate, and the target
@@ -544,7 +544,8 @@ open class JTAppleCalendarView: UIView {
                             .calendarOffsetIsAlreadyAtScrollPosition(
                                 forOffset: topOfHeader), check == true {
 
-                        self.didEndScrollAnimation(self.calendarView)
+                        self.scrollViewDidEndScrollingAnimation(
+                                                        self.calendarView)
                         self.scrollInProgress = false
                     }
                 }

--- a/Sources/UIScrollViewDelegates.swift
+++ b/Sources/UIScrollViewDelegates.swift
@@ -10,12 +10,12 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
 
     /// Inform the scrollViewDidEndDecelerating
     /// function that scrolling just occurred
-    public func didScrollToTop(_ scrollView: UIScrollView) {
-        self.didEndDecelerating(calendarView)
+    public func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
+        self.scrollViewDidEndDecelerating(calendarView)
     }
 
     /// Tells the delegate when the user finishes scrolling the content.
-    public func willEndDragging(_ scrollView: UIScrollView,
+    public func scrollViewWillEndDragging(_ scrollView: UIScrollView,
         withVelocity velocity: CGPoint,
         targetContentOffset: UnsafeMutablePointer<CGPoint>) {
             let saveLastContentOffset = {
@@ -259,7 +259,7 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
                 // was done. User scrolled and stopped and lifted finger.
                 // Thus update the label.
                 delayRunOnMainThread(0.0) {
-                    self.didEndDecelerating(self.calendarView)
+                    self.scrollViewDidEndDecelerating(self.calendarView)
                 }
             }
             saveLastContentOffset()
@@ -270,12 +270,12 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
 
     /// Tells the delegate when a scrolling
     /// animation in the scroll view concludes.
-    public func didEndScrollAnimation(
+    public func scrollViewDidEndScrollingAnimation(
         _ scrollView: UIScrollView) {
             if
                 let shouldTrigger = triggerScrollToDateDelegate,
                 shouldTrigger == true {
-                didEndDecelerating(scrollView)
+                scrollViewDidEndDecelerating(scrollView)
                 triggerScrollToDateDelegate = nil
             }
             executeDelayedTasks()
@@ -285,7 +285,7 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
 
     /// Tells the delegate that the scroll view has
     /// ended decelerating the scrolling movement.
-    public func didEndDecelerating(_ scrollView: UIScrollView) {
+    public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let currentSegmentDates = dateSegment()
         self.delegate?.calendar(
             self,

--- a/Sources/UserInteractionFunctions.swift
+++ b/Sources/UserInteractionFunctions.swift
@@ -544,7 +544,7 @@ extension JTAppleCalendarView {
                         if let check = self
                             .calendarOffsetIsAlreadyAtScrollPosition(
                                 forIndexPath: iPath), check == true {
-                                    self.didEndScrollAnimation(
+                                    self.scrollViewDidEndScrollingAnimation(
                                         self.calendarView
                                     )
                                     self.scrollInProgress = false
@@ -604,7 +604,9 @@ extension JTAppleCalendarView {
                 // this and the scroll to header function
                 delayRunOnMainThread(0.0, closure: {
                     if  !animateScroll {
-                        self.didEndScrollAnimation(self.calendarView)
+                        self.scrollViewDidEndScrollingAnimation(
+                            self.calendarView
+                        )
                         self.scrollInProgress = false
                     }
                 })


### PR DESCRIPTION
Reverts patchthecode/JTAppleCalendar#162

Oops, this was a mistake! I should be sleeping already, haha.
I thought these functions were declared by you, but they're from the `UIScrollViewDelegate` protocol, of course. So we can't change their names or they won't be called. Sorry for that. 😳
