### PR TITLE
Fix label updating

### DIFF
--- a/Sources/UIScrollViewDelegates.swift
+++ b/Sources/UIScrollViewDelegates.swift
@@ -254,18 +254,17 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
                 default:
                     break
                 }
-            default:
-                // If we go through this route, then no animated scrolling
-                // was done. User scrolled and stopped and lifted finger.
-                // Thus update the label.
-                delayRunOnMainThread(0.0) {
-                    self.scrollViewDidEndDecelerating(self.calendarView)
-                }
+			case .none: break
             }
             saveLastContentOffset()
             delayRunOnMainThread(0.7) {
                 self.calendarView.decelerationRate = cachedDecelerationRate
             }
+		
+		// Always update the label.
+		delayRunOnMainThread(0.0) {
+			self.scrollViewDidEndDecelerating(self.calendarView)
+		}
     }
 
     /// Tells the delegate when a scrolling


### PR DESCRIPTION
If you scroll the calendar page with the finger without waiting for the full deceleration, the label update only at the very end.