### PR TITLE
Immediately clear delayed tasks

### DIFF
--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -591,10 +591,11 @@ open class JTAppleCalendarView: UIView {
 
     func executeDelayedTasks() {
         let tasksToExecute = delayedExecutionClosure
+        delayedExecutionClosure.removeAll()
+        
         for aTaskToExecute in tasksToExecute {
             aTaskToExecute()
         }
-        delayedExecutionClosure.removeAll()
     }
 
     // Only reload the dates if the datasource information has changed


### PR DESCRIPTION
Delayed tasks may have side effects that then retrigger executing delayed tasks again, causing an infinite loop. This change ensures that delayed tasks will only execute once no matter how many times executeDelayedTasks() gets called.