### PR TITLE
visibleDates() no longer improperly returning cell headers

### DIFF
--- a/Sources/UserInteractionFunctions.swift
+++ b/Sources/UserInteractionFunctions.swift
@@ -623,7 +623,7 @@ extension JTAppleCalendarView {
             return emptySegment
         }
         
-        let cellAttributes = visibleElements()
+        let cellAttributes = visibleElements(excludeHeaders: true)
         let indexPaths: [IndexPath] = cellAttributes.map { $0.indexPath }.sorted()
         return dateSegmentInfoFrom(visible: indexPaths)
     }


### PR DESCRIPTION
There is a public facing `visibleDates()` func within UserInteractionFunctions which has purpose "Returns the visible dates of the calendar." 

However, the current implementation is using ALL visible elements of the calendar view to build the valid visible dates array - it is not filtering out header views. What this means is that the visible headers in view are also creating a "valid" index path and resulting date in the final returned array. 

For example, if section header for section 1 is visible on screen, then index path [1, 0] will be added to the array along with index path for the first cell in section 1 which is also [1, 0]. The final array will show repeated dates for instances like this. This is just one example of the trouble this bug is creating. visibleElements() should be updated to visibleElements(excludeHeaders: true) for the func to perform its operation correctly.