### PR TITLE
Cells outside supported months should not be selectable

### DIFF
--- a/Sources/UICollectionViewDelegates.swift
+++ b/Sources/UICollectionViewDelegates.swift
@@ -196,23 +196,37 @@ extension JTAppleCalendarView: UICollectionViewDelegate, UICollectionViewDataSou
     /// It does not call this method when you programmatically
     /// set the selection.
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let delegate = self.delegate,
+            let infoOfDateSelectedByUser = dateOwnerInfoFromPath(indexPath) else
+        {
+            return
+        }
+        
+        let date = infoOfDateSelectedByUser.date
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        
+        // If the date is not within valid boundaries, then exit
+        guard let firstDayOfDate = calendar.date(from: components),
+            firstDayOfDate >= startOfMonthCache! && firstDayOfDate <= endOfMonthCache! else
+        {
+            return
+        }
+        
         // index paths to be reloaded should be index to the left and right of the selected index
         let indexPathsToReload = rangeSelectionWillBeUsed ? validForwardAndBackwordSelectedIndexes(forIndexPath: indexPath) : []
-        guard
-            let delegate = self.delegate,
-            let infoOfDateSelectedByUser = dateOwnerInfoFromPath(indexPath) else {
-                return
-        }
+        
         // Update model
-        addCellToSelectedSetIfUnselected(indexPath, date: infoOfDateSelectedByUser.date)
+        addCellToSelectedSetIfUnselected(indexPath, date: date)
         let selectedCell = collectionView.cellForItem(at: indexPath) as? JTAppleDayCell
         // If cell has a counterpart cell, then select it as well
         let cellState = cellStateFromIndexPath(indexPath,
-            withDateInfo: infoOfDateSelectedByUser, cell: selectedCell)
+                                               withDateInfo: infoOfDateSelectedByUser,
+                                               cell: selectedCell)
         var pathsToReload = indexPathsToReload
         if let selectedCounterPartIndexPath = selectCounterPartCellIndexPathIfExists(indexPath,
-                                                                                     date: infoOfDateSelectedByUser.date,
-                                                                                     dateOwner: cellState.dateBelongsTo) {
+                                                                                     date: date,
+                                                                                     dateOwner: cellState.dateBelongsTo)
+        {
             // ONLY if the counterPart cell is visible,
             // then we need to inform the delegate
             if !pathsToReload.contains(selectedCounterPartIndexPath) {
@@ -226,6 +240,6 @@ extension JTAppleCalendarView: UICollectionViewDelegate, UICollectionViewDataSou
                 self.batchReloadIndexPaths(pathsToReload)
             }
         }
-        delegate.calendar(self, didSelectDate: infoOfDateSelectedByUser.date, cell: selectedCell?.view, cellState: cellState)
+        delegate.calendar(self, didSelectDate: date, cell: selectedCell?.view, cellState: cellState)
     }
 }


### PR DESCRIPTION
Hey @patchthecode - thanks for all the help this last week. I think this will represent my last change for the behavior I need... but who knows :)

Within the UserInteractionFunctions.swift, there is a func selectDates(...) which works well. I have used this in a few spots of my project and I've noticed that it also protects against selecting unsupported dates i.e. dates that are outside the start and end months of the calendar. I think this same logic should be applied to the UICollectionViewDelegate method didSelectItemAt for the CalendarView. I've noticed in testing that manual selection does not protect against unsupported date selection - the use case is when you scroll all the way to the end of your calendar and select an outdate. If this is done programmatically the unsupported dates are not selected - if selected manually the date is allowed to be selected. This is no good.

This PR also includes a change to make calendarView prop a public facing var - I changed this because I needed access to the collection view for implementing a tap+drag selection interaction using a pan gesture recognizer. If there are problems you have with this let me know. Thanks again!