### PR TITLE
Fixed an issue that caused scroll to overshoot when using headers.

### DIFF
--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -492,7 +492,12 @@ open class JTAppleCalendarView: UIView {
                 if let validHandler = completionHandler {
                     self.delayedExecutionClosure.append(validHandler)
                 }
-                let topOfHeader = CGPoint(x: attributes.frame.origin.x, y: attributes.frame.origin.y)
+                // Prevents the scroll from overshooting.
+                let maxY = max(0, self.calendarView.contentSize.height - self.calendarView.frame.size.height)
+                let topOfHeader = CGPoint(
+                    x: attributes.frame.origin.x,
+                    y: min(maxY, attributes.frame.origin.y)
+                )
                 self.scrollInProgress = true
                 self.calendarView.setContentOffset(topOfHeader, animated: animation)
                 if !animation {


### PR DESCRIPTION
This fixes an issue where scrolling to a date that is at the end of the vertically-scrolling calendar caused overshooting.

Reproducing this issue requires the following:

- Vertically-scrolling calendar that has enough content to make it scrollable
- Calendar must use headers
- Using `.centeredVertically` or `.top` for `preferredScrollPosition` when calling `scroll`
- Scrolling to a date that is at the end of the calendar

This example is taken when scrolling to the last date of the calendar with `preferredScrollPosition` set to `.top`.

Before:

![image](https://cloud.githubusercontent.com/assets/2168023/24343182/c8ef2c84-12cd-11e7-90d3-fe86d337b21b.png)

After:

![image](https://cloud.githubusercontent.com/assets/2168023/24343081/3ef6d748-12cd-11e7-9ad6-788f5f22a87d.png)
