### PR TITLE
Include the 25th when matching counterpart dates

### DIFF
--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -736,7 +736,7 @@ extension JTAppleCalendarView {
                 itemIndex = extraIndex
                 let reCalcRapth = IndexPath(item: itemIndex, section: section)
                 retval = reCalcRapth
-            } else if case 26...31 = dayIndex { // check the following month
+            } else if case 25...31 = dayIndex { // check the following month
                 let periodApart = calendar.dateComponents([.month], from: startOfMonthCache, to: date)
                 let monthSectionIndex = periodApart.month!
                 if monthSectionIndex + 1 >= monthInfo.count {


### PR DESCRIPTION
Hi

This is a tiny fix for the 25th as an inDate not being reloaded when calling reloadDates. The 25th can appear as an inDate on months with 30 days. An example is between June - July 2017 when using Sunday as the first day of the week.
