### PR TITLE
Restore minimum visible date on reloadData()

### DIFF
--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -556,6 +556,9 @@ open class JTAppleCalendarView: UIView {
             for indexPath in self.theSelectedIndexPaths { self.restoreSelectionStateForCellAtIndexPath(indexPath) }
         }
         
+        // Restore the min date.
+        setMinVisibleDate()
+        
         if let validAnchorDate = anchorDate {
             // If we have a valid anchor date, this means we want to
             // scroll


### PR DESCRIPTION
Hello again,

My usage of the calendar involves setting the calendarView's `delegate` and `dataSource` in viewDidLoad, and then calling `calendarView.reloadData()` in a completion block of a network call in viewWillAppear with the proper dates we actually want displayed. (Not that different from reloading a table view upon a network request.)

Due to some admittedly unusual view controller hierarchy stuff I'm doing (I think around view controller containment), the calendar view's `traitCollectionDidChange` method is being called before my `reloadData()` completes, and `traitCollectionDidChange` is calling `setMinVisibleDate()`. Since my app hasn't yet configured which dates we want visible yet, `setMinVisibleDate()` is setting it to the very top of the collection view (i.e. the earliest dates that our calendar is configured for). Then when the network request completes and we `reloadData()`, the min visible date isn't being updated from that call.

It seems like `reloadData()` tries to restore all previous state, but misses the minimum visible date. This patch fixes it.

It looks like you're working on a major version change to 7.0, but I'm hoping you'll accept this as a patch to 6.1.7. 