### PR TITLE
Account for collection view section insets

### DIFF
--- a/Sources/UserInteractionFunctions.swift
+++ b/Sources/UserInteractionFunctions.swift
@@ -493,7 +493,7 @@ extension JTAppleCalendarView {
                 if point != nil {
                     if let currentSection = self.currentSection() {
                         let section = CGFloat(currentSection) + 1
-                        point!.x += (self.sectionInset.top + self.sectionInset.bottom) * section
+                        point!.y += (self.sectionInset.top + self.sectionInset.bottom) * section
                     }
                 }
             }

--- a/Sources/UserInteractionFunctions.swift
+++ b/Sources/UserInteractionFunctions.swift
@@ -479,9 +479,23 @@ extension JTAppleCalendarView {
         
         var point: CGPoint?
         switch self.scrollingMode {
-        case .stopAtEach, .stopAtEachSection, .stopAtEachCalendarFrameWidth, .nonStopToSection:
-            if self.scrollDirection == .horizontal || (scrollDirection == .vertical && !calendarViewLayout.thereAreHeaders) {
+        case .stopAtEach, .stopAtEachSection, .stopAtEachCalendarFrameWidth:
+            if self.scrollDirection == .horizontal {
                 point = self.targetPointForItemAt(indexPath: sectionIndexPath)
+                if point != nil {
+                    if let currentSection = self.currentSection() {
+                        let section = CGFloat(currentSection) + 1
+                        point!.x += (self.sectionInset.left + self.sectionInset.right) * section
+                    }
+                } 
+            } else if (scrollDirection == .vertical && !calendarViewLayout.thereAreHeaders) {
+                point = self.targetPointForItemAt(indexPath: sectionIndexPath)
+                if point != nil {
+                    if let currentSection = self.currentSection() {
+                        let section = CGFloat(currentSection) + 1
+                        point!.x += (self.sectionInset.top + self.sectionInset.bottom) * section
+                    }
+                }
             }
         default:
             break


### PR DESCRIPTION
When scrolling to a date, section insets are used to calculate the correct scroll offset.

see https://github.com/patchthecode/JTAppleCalendar/issues/419