### PR TITLE
Fix adjustment between cells

### DIFF
--- a/Sources/JTAppleCalendarLayout.swift
+++ b/Sources/JTAppleCalendarLayout.swift
@@ -509,7 +509,7 @@ class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutProtoc
             }
         }
         let width = cellSize.width - ((sectionInset.left / 7) + (sectionInset.right / 7))
-        var size: (width: CGFloat, height: CGFloat) = (width, cellSize.height)
+        var size: (width: CGFloat, height: CGFloat) = (width.rounded(), cellSize.height)
         if itemSizeWasSet {
             if scrollDirection == .vertical {
                 size.height = cellSize.height


### PR DESCRIPTION
Since the width wasn’t being rounded, the horizontal space between cells was not properly fitting to each other.

**Before rounding**
![wrong](https://cloud.githubusercontent.com/assets/1409041/26362722/2f5b0054-3fdf-11e7-8299-ff01eaa7a93c.png)


**After rounding**
![screen shot 2017-05-23 at 17 36 09](https://cloud.githubusercontent.com/assets/1409041/26362533/8261f420-3fde-11e7-841f-c8d3448f4ac0.png)
