### PR TITLE
Rename ScrollingMode to make sense for both horizontal and vertical scroll direction

### DIFF
--- a/Example/JTAppleCalendar iOS Example/ViewController.swift
+++ b/Example/JTAppleCalendar iOS Example/ViewController.swift
@@ -44,7 +44,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func scrollFixed(_ sender: Any) {
-        calendarView.scrollingMode = .stopAtEachCalendarFrameWidth
+        calendarView.scrollingMode = .stopAtEachCalendarFrame
     }
     @IBAction func showPrepost(_ sender: UIButton) {
         prePostVisibility = {state, cell in

--- a/Sources/CalendarEnums.swift
+++ b/Sources/CalendarEnums.swift
@@ -60,8 +60,8 @@ public enum ReadingOrientation {
 
 /// Configures the behavior of the scrolling mode of the calendar
 public enum ScrollingMode {
-    /// stopAtEachCalendarFrameWidth - non-continuous scrolling that will stop at each frame width
-    case stopAtEachCalendarFrameWidth
+    /// stopAtEachCalendarFrame - non-continuous scrolling that will stop at each frame
+    case stopAtEachCalendarFrame
     /// stopAtEachSection - non-continuous scrolling that will stop at each section
     case stopAtEachSection
     /// stopAtEach - non-continuous scrolling that will stop at each custom interval
@@ -77,7 +77,7 @@ public enum ScrollingMode {
     
     func pagingIsEnabled() -> Bool {
         switch self {
-        case .stopAtEachCalendarFrameWidth: return true
+        case .stopAtEachCalendarFrame: return true
         default: return false
         }
     }

--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -155,7 +155,7 @@ open class JTAppleCalendarView: UICollectionView {
             
         } else {
             switch self.scrollingMode {
-            case .stopAtEach, .stopAtEachSection, .stopAtEachCalendarFrameWidth:
+            case .stopAtEach, .stopAtEachSection, .stopAtEachCalendarFrame:
                 if self.scrollDirection == .horizontal || (scrollDirection == .vertical && !calendarViewLayout.thereAreHeaders) {
                     retval = self.targetPointForItemAt(indexPath: sectionIndexPath) ?? .zero
                 }
@@ -182,16 +182,16 @@ open class JTAppleCalendarView: UICollectionView {
     }
     
     /// Configure the scrolling behavior
-    open var scrollingMode: ScrollingMode = .stopAtEachCalendarFrameWidth {
+    open var scrollingMode: ScrollingMode = .stopAtEachCalendarFrame {
         didSet {
             switch scrollingMode {
-            case .stopAtEachCalendarFrameWidth: decelerationRate = UIScrollViewDecelerationRateFast
+            case .stopAtEachCalendarFrame: decelerationRate = UIScrollViewDecelerationRateFast
             case .stopAtEach, .stopAtEachSection: decelerationRate = UIScrollViewDecelerationRateFast
             case .nonStopToSection, .nonStopToCell, .nonStopTo, .none: decelerationRate = UIScrollViewDecelerationRateNormal
             }
             #if os(iOS)
                 switch scrollingMode {
-                case .stopAtEachCalendarFrameWidth:
+                case .stopAtEachCalendarFrame:
                     isPagingEnabled = true
                 default:
                     isPagingEnabled = false
@@ -239,7 +239,7 @@ open class JTAppleCalendarView: UICollectionView {
         
         #if os(iOS)
             if isPagingEnabled {
-                scrollingMode = .stopAtEachCalendarFrameWidth
+                scrollingMode = .stopAtEachCalendarFrame
             } else {
                 scrollingMode = .none
             }
@@ -284,7 +284,7 @@ open class JTAppleCalendarView: UICollectionView {
         let theTargetContentOffset: CGFloat = scrollDirection == .horizontal ? targetCellFrame.origin.x : targetCellFrame.origin.y
         var fixedScrollSize: CGFloat = 0
         switch scrollingMode {
-        case .stopAtEachSection, .stopAtEachCalendarFrameWidth, .nonStopToSection:
+        case .stopAtEachSection, .stopAtEachCalendarFrame, .nonStopToSection:
             if self.scrollDirection == .horizontal || (scrollDirection == .vertical && !calendarViewLayout.thereAreHeaders) {
                 // Horizontal has a fixed width.
                 // Vertical with no header has fixed height

--- a/Sources/UIScrollViewDelegates.swift
+++ b/Sources/UIScrollViewDelegates.swift
@@ -109,7 +109,7 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
         case let .stopAtEach(customInterval: interval):
             let calculatedOffset = calculatedCurrentFixedContentOffsetFrom(interval)
             setTargetContentOffset(calculatedOffset)
-        case .stopAtEachCalendarFrameWidth:
+        case .stopAtEachCalendarFrame:
             #if os(tvOS)
                 let interval = self.scrollDirection == .horizontal ? scrollView.frame.width : scrollView.frame.height
                 let calculatedOffset =

--- a/Sources/UserInteractionFunctions.swift
+++ b/Sources/UserInteractionFunctions.swift
@@ -494,7 +494,7 @@ extension JTAppleCalendarView {
         
         var point: CGPoint?
         switch self.scrollingMode {
-        case .stopAtEach, .stopAtEachSection, .stopAtEachCalendarFrameWidth, .nonStopToSection:
+        case .stopAtEach, .stopAtEachSection, .stopAtEachCalendarFrame, .nonStopToSection:
             if self.scrollDirection == .horizontal || (scrollDirection == .vertical && !calendarViewLayout.thereAreHeaders) {
                 point = self.targetPointForItemAt(indexPath: sectionIndexPath)
             }


### PR DESCRIPTION
The idea is to move from `stopAtEachCalendarFrameWidth` to `stopAtEachCalendarFrame` for a much cleaner API