### PR TITLE
Fixed End of month generation for Custom calendars.

### DIFF
--- a/Sources/GlobalFunctionsAndExtensions.swift
+++ b/Sources/GlobalFunctionsAndExtensions.swift
@@ -33,10 +33,12 @@ extension Calendar {
 
     func startOfMonth(for date: Date) -> Date? {
         guard let comp = dateFormatterComponents(from: date) else { return nil }
+        Calendar.formatter.calendar = self
         return Calendar.formatter.date(from: "\(comp.year) \(comp.month) 01")
     }
     
     func endOfMonth(for date: Date) -> Date? {
+        Calendar.formatter.calendar = self
         guard
             let comp = dateFormatterComponents(from: date),
             let day = self.range(of: .day, in: .month, for: date)?.count,
@@ -51,6 +53,7 @@ extension Calendar {
         // Setup the dateformatter to this instance's settings
         Calendar.formatter.timeZone = self.timeZone
         Calendar.formatter.locale = self.locale
+        Calendar.formatter.calendar = self
         
         let comp = self.dateComponents([.year, .month], from: date)
         


### PR DESCRIPTION
Hi,
When finding the end of month day, the current implementation uses a generic date formatter that ignores the calendar and uses the device's Calendar as a reference.

Not all calendars are the same. 
To elaborate on the issue, Gregorian calendar alternates between 31 and 30 days in month, while in Persian Calendar (Jalali) the first 6 months are all 31 days, and the following 5 months have 30 days and the last month is 29 (or 30 in a leap year). Now, in the current implementation, the static formatter uses the Device's calendar to decide on the month's number of days, ignoring the fact that the calendar set for the CalendarView might differ from the device's calendar.
This fix sets the record right with the `Calendar`'s extension that gets the range of days in a month.