### PR TITLE
add scrollViewDidScroll to calendar delegate

### DIFF
--- a/Sources/JTCalendarProtocols.swift
+++ b/Sources/JTCalendarProtocols.swift
@@ -36,7 +36,7 @@ public extension JTAppleCalendarViewDelegate {
     func calendarSizeForMonths(_ calendar: JTAppleCalendarView?) -> MonthSize? { return nil }
     func sizeOfDecorationView(indexPath: IndexPath) -> CGRect { return .zero }
     func scrollDidEndDecelerating(for calendar: JTAppleCalendarView) {}
-    
+    func calendarDidScroll(_ calendar: JTAppleCalendarView) {}
 }
 
 /// The JTAppleCalendarViewDataSource protocol is adopted by an
@@ -124,6 +124,9 @@ public protocol JTAppleCalendarViewDelegate: class {
     
     /// Informs the delegate that the user just lifted their finger from swiping the calendar
     func scrollDidEndDecelerating(for calendar: JTAppleCalendarView)
+    
+    /// Tells the delegate that a scroll occured
+    func calendarDidScroll(_ calendar: JTAppleCalendarView)
     
     func calendarSizeForMonths(_ calendar: JTAppleCalendarView?) -> MonthSize?
     func sizeOfDecorationView(indexPath: IndexPath) -> CGRect

--- a/Sources/UIScrollViewDelegates.swift
+++ b/Sources/UIScrollViewDelegates.swift
@@ -245,4 +245,9 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
             self.calendarDelegate?.calendar(self, didScrollToDateSegmentWith: dates)
         }
     }
+    
+    /// Tells the delegate that a scroll occured
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        self.calendarDelegate?.calendarDidScroll(self)
+    }
 }


### PR DESCRIPTION
I need to know when the calendar is scrolling to make custom stuff in a external view.
I always need this delegate methods usually when I'm using scrollview, for fancy animation graphics for example (fading opacity when a view is scrolling), so it could be useful for others too.