### PR TITLE
Fix for repeating dates in week view

### DIFF
--- a/Sources/CalendarStructs.swift
+++ b/Sources/CalendarStructs.swift
@@ -296,6 +296,11 @@ struct JTAppleDateConfigGenerator {
                         numberOfPostDatesForThisMonth =
                             maxNumberOfDaysInWeek * numberOfRowsToGenerateForCurrentMonth - (numberOfDaysInMonthFixed + numberOfPreDatesForThisMonth)
                         numberOfDaysInMonthVariable += numberOfPostDatesForThisMonth
+                        if numberOfRowsPerSectionThatUserWants == 1 && numberOfPostDatesForThisMonth > 0 {
+                            let numberOfDuplicateRows = ((numberOfPostDatesForThisMonth - 1) / maxNumberOfDaysInWeek) + 1
+                            numberOfDaysInMonthVariable -= (numberOfDuplicateRows * maxNumberOfDaysInWeek)
+                            numberOfPostDatesForThisMonth = 0
+                        }
                     default:
                         break
                     }


### PR DESCRIPTION
This is a fix for repeating dates in calendar with 1 row. We can eliminate duplicates by removing rows with outdates (post dates) in it. Last few removed monthDates that have outDates in the same week (row) will be visible in next month's week as inDates.
This is a fix for old issues:
https://github.com/patchthecode/JTAppleCalendar/issues/129
https://github.com/patchthecode/JTAppleCalendar/issues/384 ...
