### PR TITLE
Fix didScrollToDateSegmentWith not called when dragging

### DIFF
--- a/Sources/JTCalendarProtocols.swift
+++ b/Sources/JTCalendarProtocols.swift
@@ -29,6 +29,7 @@ public extension JTAppleCalendarViewDelegate {
     func calendar(_ calendar: JTAppleCalendarView, didSelectDate date: Date, cell: JTAppleCell?, cellState: CellState) {}
     func calendar(_ calendar: JTAppleCalendarView, didDeselectDate date: Date, cell: JTAppleCell?, cellState: CellState) {}
     func calendar(_ calendar: JTAppleCalendarView, didScrollToDateSegmentWith visibleDates: DateSegmentInfo) {}
+    func calendar(_ calendar: JTAppleCalendarView, didDragToDateSegmentWith visibleDates: DateSegmentInfo) {}
     func calendar(_ calendar: JTAppleCalendarView, headerViewForDateRange range: (start: Date, end: Date), at indexPath: IndexPath) -> JTAppleCollectionReusableView {
         assert(false, "You have implemted a header size function, but forgot to implement the `headerViewForDateRange` function")
         return JTAppleCollectionReusableView()
@@ -104,6 +105,14 @@ public protocol JTAppleCalendarViewDelegate: class {
     ///     - startDate: The date at the start of the segment.
     ///     - endDate: The date at the end of the segment.
     func calendar(_ calendar: JTAppleCalendarView, didScrollToDateSegmentWith visibleDates: DateSegmentInfo)
+
+    /// Tells the delegate that the JTAppleCalendar view
+    /// dragged to a segment beginning and ending with a particular date
+    /// - Parameters:
+    ///     - calendar: The JTAppleCalendar view giving this information.
+    ///     - startDate: The date at the start of the segment.
+    ///     - endDate: The date at the end of the segment.
+    func calendar(_ calendar: JTAppleCalendarView, didDragToDateSegmentWith visibleDates: DateSegmentInfo)
 
     /// Tells the delegate that the JTAppleCalendar is about to display
     /// a date-cell. This is the point of customization for your date cells

--- a/Sources/UIScrollViewDelegates.swift
+++ b/Sources/UIScrollViewDelegates.swift
@@ -255,7 +255,20 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
             self.calendarDelegate?.calendar(self, didScrollToDateSegmentWith: dates)
         }
     }
-    
+
+    /// Tells the delegate when dragging
+    /// ended in the scroll view.
+    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        // Only call the delegate, when not decelerating
+        // otherwise, didScrollToDateSegmentWith is called
+        // after finishing animation
+        if !decelerate {
+            visibleDates {[unowned self] dates in
+                self.calendarDelegate?.calendar(self, didDragToDateSegmentWith: dates)
+            }
+        }
+    }
+
     /// Tells the delegate that a scroll occured
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         calendarDelegate?.calendarDidScroll(self)


### PR DESCRIPTION
Hi,

I experienced an issue with the `didScrollToDateSegmentWith` delegate in my current setup. 
I am using a single line calendar with bounce disabled (infinite scrolling)
The method is not called, when the user drags the calendar strip, because the scrollview is never decelerating. 
I added a new delegate method called 
```swift
func calendar(_ calendar: JTAppleCalendarView, didDragToDateSegmentWith visibleDates: DateSegmentInfo)
``` 
that closes this gap. In the UIScrollviewDelegate I implemented the `scrollViewDidEndDragging ` method and I check for `willDecelerate`. Only if `willDecelerate` is false, the user actually dragged and released the touch at a fixed position, otherwise we continue and `didScrollToDateSegmentWith` is called after finishing animating.
