### PR TITLE
Add init function to CellState

### DIFF
--- a/Sources/CalendarStructs.swift
+++ b/Sources/CalendarStructs.swift
@@ -62,6 +62,31 @@ public struct CellState {
     /// Shows if a cell's selection/deselection was done either programatically or by the user
     /// This variable is guranteed to be non-nil inside of a didSelect/didDeselect function
     public var selectionType: SelectionType? = nil
+
+    /// Init function
+    public init (isSelected: Bool,
+                 text: String,
+                 dateBelongsTo: DateOwner,
+                 date: Date,
+                 day: DaysOfWeek,
+                 row: @escaping () -> Int,
+                 column: @escaping () -> Int,
+                 dateSection: @escaping () -> (range: (start: Date, end: Date), month: Int, rowCount: Int),
+                 selectedPosition: @escaping () -> SelectionRangePosition,
+                 cell: @escaping () -> JTAppleCell?,
+                 selectionType: SelectionType? = nil) {
+        self.isSelected = isSelected
+        self.text = text
+        self.dateBelongsTo = dateBelongsTo
+        self.date = date
+        self.day = day
+        self.row = row
+        self.column = column
+        self.dateSection = dateSection
+        self.selectedPosition = selectedPosition
+        self.cell = cell
+        self.selectionType = selectionType
+    }
 }
 
 /// Defines the parameters which configures the calendar.

--- a/Sources/CalendarStructs.swift
+++ b/Sources/CalendarStructs.swift
@@ -64,17 +64,17 @@ public struct CellState {
     public var selectionType: SelectionType? = nil
 
     /// Init function
-    public init (isSelected: Bool,
-                 text: String,
-                 dateBelongsTo: DateOwner,
-                 date: Date,
-                 day: DaysOfWeek,
-                 row: @escaping () -> Int,
-                 column: @escaping () -> Int,
-                 dateSection: @escaping () -> (range: (start: Date, end: Date), month: Int, rowCount: Int),
-                 selectedPosition: @escaping () -> SelectionRangePosition,
-                 cell: @escaping () -> JTAppleCell?,
-                 selectionType: SelectionType? = nil) {
+    public init(isSelected: Bool,
+                text: String,
+                dateBelongsTo: DateOwner,
+                date: Date,
+                day: DaysOfWeek,
+                row: @escaping () -> Int,
+                column: @escaping () -> Int,
+                dateSection: @escaping () -> (range: (start: Date, end: Date), month: Int, rowCount: Int),
+                selectedPosition: @escaping () -> SelectionRangePosition,
+                cell: @escaping () -> JTAppleCell?,
+                selectionType: SelectionType? = nil) {
         self.isSelected = isSelected
         self.text = text
         self.dateBelongsTo = dateBelongsTo


### PR DESCRIPTION
Add init function to CellState for Swift 4.1 changes. Mainly for my own testing purposes due to:

https://github.com/apple/swift-evolution/blob/master/proposals/0189-restrict-cross-module-struct-initializers.md