### PR TITLE
Removing `cachedDecelerationRate` in scrollViewWillEndDragging method

### DIFF
--- a/Sources/JTAppleCalendarView.swift
+++ b/Sources/JTAppleCalendarView.swift
@@ -168,15 +168,19 @@ open class JTAppleCalendarView: UICollectionView {
         get { return theData.sectionToMonthMap }
         set { theData.sectionToMonthMap = monthMap }
     }
-    
+
+    var decelerationRateMatchingScrollingMode: CGFloat {
+        switch scrollingMode {
+        case .stopAtEachCalendarFrame: return UIScrollViewDecelerationRateFast
+        case .stopAtEach, .stopAtEachSection: return UIScrollViewDecelerationRateFast
+        case .nonStopToSection, .nonStopToCell, .nonStopTo, .none: return UIScrollViewDecelerationRateNormal
+        }
+    }
+
     /// Configure the scrolling behavior
     open var scrollingMode: ScrollingMode = .stopAtEachCalendarFrame {
         didSet {
-            switch scrollingMode {
-            case .stopAtEachCalendarFrame: decelerationRate = UIScrollViewDecelerationRateFast
-            case .stopAtEach, .stopAtEachSection: decelerationRate = UIScrollViewDecelerationRateFast
-            case .nonStopToSection, .nonStopToCell, .nonStopTo, .none: decelerationRate = UIScrollViewDecelerationRateNormal
-            }
+            decelerationRate = decelerationRateMatchingScrollingMode
             #if os(iOS)
                 switch scrollingMode {
                 case .stopAtEachCalendarFrame:

--- a/Sources/UIScrollViewDelegates.swift
+++ b/Sources/UIScrollViewDelegates.swift
@@ -36,8 +36,6 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
     open func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
         guard let theCurrentSection = currentSection() else { return }
         
-        let cachedDecelerationRate = decelerationRate
-        
         let contentSizeEndOffset: CGFloat
         var contentOffset: CGFloat = 0,
         theTargetContentOffset: CGFloat = 0,
@@ -225,7 +223,7 @@ extension JTAppleCalendarView: UIScrollViewDelegate {
         }
         saveLastContentOffset(CGPoint(x: targetContentOffset.pointee.x, y: targetContentOffset.pointee.y))
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-            self.decelerationRate = cachedDecelerationRate
+            self.decelerationRate = self.decelerationRateMatchingScrollingMode
         }
         
         DispatchQueue.main.async {


### PR DESCRIPTION
The scrollView could end up having all the time a decelerationRate set to `UIScrollViewDecelerationRateFast`.

Here is how to reproduce:
1- Have a calendar with a `scrollingMode` set to `.none`
2- Flick the scrollView so it scrolls fast
3- Stop it with your finger
4- Quickly, flick it again
=> The scrollView now has a decelerationRate equals to `UIScrollViewDecelerationRateFast`.

This PR makes sure to keep to good decelerationRate.