### PR TITLE
shouldTriggerSelectionDelegate loop fixes

### DIFF
--- a/Sources/UICollectionViewDelegates.swift
+++ b/Sources/UICollectionViewDelegates.swift
@@ -92,13 +92,13 @@ extension JTAppleCalendarView: UICollectionViewDelegate, UICollectionViewDataSou
     /// Asks the delegate if the specified item should be selected.
     /// true if the item should be selected or false if it should not.
     public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
-        return handleShouldSelectionValueChange(collectionView, action: .shouldSelect, indexPath: indexPath, selectionType: .userInitiated)
+        return handleShouldSelectionValueChange(collectionView, action: .shouldSelect, indexPath: indexPath, selectionType: .userInitiated, shouldTriggerSelectionDelegate: true)
     }
     
     /// Asks the delegate if the specified item should be deselected.
     /// true if the item should be deselected or false if it should not.
     public func collectionView(_ collectionView: UICollectionView, shouldDeselectItemAt indexPath: IndexPath) -> Bool {
-        return handleShouldSelectionValueChange(collectionView, action: .shouldDeselect, indexPath: indexPath, selectionType: .userInitiated)
+        return handleShouldSelectionValueChange(collectionView, action: .shouldDeselect, indexPath: indexPath, selectionType: .userInitiated, shouldTriggerSelectionDelegate: true)
     }
 
     /// Tells the delegate that the item at the specified index
@@ -183,7 +183,10 @@ extension JTAppleCalendarView: UICollectionViewDelegate, UICollectionViewDataSou
         }
     }
     
-    func handleShouldSelectionValueChange(_ collectionView: UICollectionView, action: ShouldSelectionAction, indexPath: IndexPath, selectionType: SelectionType) -> Bool {
+    func handleShouldSelectionValueChange(_ collectionView: UICollectionView, action: ShouldSelectionAction, indexPath: IndexPath, selectionType: SelectionType, shouldTriggerSelectionDelegate: Bool) -> Bool {
+        guard shouldTriggerSelectionDelegate else {
+            return true
+        }
         if let
             delegate = calendarDelegate,
             let infoOfDate = dateOwnerInfoFromPath(indexPath) {

--- a/Sources/UserInteractionFunctions.swift
+++ b/Sources/UserInteractionFunctions.swift
@@ -372,13 +372,13 @@ extension JTAppleCalendarView {
     }
 
     func programaticallyDeselectItem(at indexPath: IndexPath, shouldTriggerSelectionDelegate: Bool) {
-        if !handleShouldSelectionValueChange(self, action: .shouldDeselect, indexPath: indexPath, selectionType: .programatic) { return }
+        if !handleShouldSelectionValueChange(self, action: .shouldDeselect, indexPath: indexPath, selectionType: .programatic, shouldTriggerSelectionDelegate: shouldTriggerSelectionDelegate) { return }
         deselectItem(at: indexPath, animated: false)
         handleSelectionValueChanged(self, action: .didDeselect, indexPath: indexPath, selectionType: .programatic, shouldTriggerSelectionDelegate: shouldTriggerSelectionDelegate)
     }
 
     func programaticallySelectItem(at indexPath: IndexPath, shouldTriggerSelectionDelegate: Bool) {
-        if !handleShouldSelectionValueChange(self, action: .shouldSelect, indexPath: indexPath, selectionType: .programatic) { return }
+        if !handleShouldSelectionValueChange(self, action: .shouldSelect, indexPath: indexPath, selectionType: .programatic, shouldTriggerSelectionDelegate: shouldTriggerSelectionDelegate) { return }
         selectItem(at: indexPath, animated: false, scrollPosition: [])
         handleSelectionValueChanged(self, action: .didSelect, indexPath: indexPath, selectionType: .programatic, shouldTriggerSelectionDelegate: shouldTriggerSelectionDelegate)
     }


### PR DESCRIPTION
While using 
```swift
calendar.selectDates(from: start, to: end, triggerSelectionDelegate: false, keepSelectionIfMultiSelectionAllowed: true)
```
in
```swift
func calendar(_ calendar: JTAppleCalendarView, shouldSelectDate date: Date, cell: JTAppleCell?, cellState: CellState) -> Bool
``` 

`triggerSelectionDelegate = false` isn't working and create an infinite loop crash