### PR TITLE
Fixes #419 for .vertical

### DIFF
--- a/Sources/JTAppleCalendarLayout.swift
+++ b/Sources/JTAppleCalendarLayout.swift
@@ -595,7 +595,7 @@ class JTAppleCalendarLayout: UICollectionViewLayout, JTAppleCalendarLayoutProtoc
             return cellCache[section]![0].4 * CGFloat(maxNumberOfDaysInWeek) + sectionInset.left + sectionInset.right
         case .vertical:
             let headerSizeOfSection = !headerCache.isEmpty ? headerCache[section]!.5 : 0
-            return cellCache[section]![0].5 * CGFloat(numberOfRowsForMonth(section)) + headerSizeOfSection
+            return cellCache[section]![0].5 * CGFloat(numberOfRowsForMonth(section)) + headerSizeOfSection + sectionInset.top + sectionInset.bottom
         }
     }
     


### PR DESCRIPTION
I found #419 by search for `scrollToDate` and `sectionInset` to resolve a problem. Then I reached [fix for this issue](https://github.com/patchthecode/JTAppleCalendar/commit/2d6c54dda05ee7d5502e731946a3a9486307ad2f), but I found that this wasn't enough to resolve the problem in case of use as `.vertical`.