### PR TITLE
Fix Scrolling in Scroll to Header Function with Animation

### DIFF
--- a/Sources/InternalActionFunctions.swift
+++ b/Sources/InternalActionFunctions.swift
@@ -112,6 +112,7 @@ extension JTAppleCalendarView {
                 !animation {
                 self.scrollViewDidEndScrollingAnimation(self)
             }
+            self.isScrollInProgress = false
         }
     }
     


### PR DESCRIPTION
Fix Issue #995 

We used the same implementation as in the other `scrollTo` method.