### PR TITLE
Fix delegate and datasource strong refer

### DIFF
--- a/Sources/JTAppleCalendar/JTACMonthView.swift
+++ b/Sources/JTAppleCalendar/JTACMonthView.swift
@@ -70,12 +70,12 @@ open class JTACMonthView: UICollectionView {
     }
     
     /// The object that acts as the delegate of the calendar view.
-    open var calendarDelegate: JTACMonthViewDelegate? {
+    weak open var calendarDelegate: JTACMonthViewDelegate? {
         didSet { lastMonthSize = sizesForMonthSection() }
     }
     
     /// The object that acts as the data source of the calendar view.
-    open var calendarDataSource: JTACMonthViewDataSource? {
+    weak open var calendarDataSource: JTACMonthViewDataSource? {
         didSet { setupMonthInfoAndMap() } // Refetch the data source for a data source change
     }
     

--- a/Sources/JTAppleCalendar/JTACMonthViewProtocols.swift
+++ b/Sources/JTAppleCalendar/JTACMonthViewProtocols.swift
@@ -31,8 +31,8 @@ import UIKit
 /// the calendar-view object with the information it needs to construct and
 /// then modify it self
 @available(*, unavailable, renamed: "JTACMonthViewDataSource")
-public protocol JTAppleCalendarViewDataSource{}
-public protocol JTACMonthViewDataSource {
+public protocol JTAppleCalendarViewDataSource: class {}
+public protocol JTACMonthViewDataSource: class {
     /// Asks the data source to return the start and end boundary dates
     /// as well as the calendar to use. You should properly configure
     /// your calendar at this point.
@@ -48,7 +48,7 @@ public protocol JTACMonthViewDataSource {
 /// allow the delegate to manage selections, and configure the cells
 @available(*, unavailable, renamed: "JTACMonthViewDelegate")
 public protocol JTAppleCalendarViewDelegate: class {}
-public protocol JTACMonthViewDelegate {
+public protocol JTACMonthViewDelegate: class {
     /// Asks the delegate if selecting the date-cell with a specified date is
     /// allowed
     /// - Parameters:


### PR DESCRIPTION
Hi! Thanks for releasing v8.0🎉

I probably found the cause of memory leak.
`JTACMonthView.calendarDelegate` and `.calendarDataSource` have strong reference.

`JTACYearView` has weak reference.

```
weak open var calendarDelegate: JTACYearViewDelegate?
weak open var calendarDataSource: JTACYearViewDataSource? {
    didSet { setupYearViewCalendar() }
}
```

So, I fixed `JTACMonthView` to have weak reference.