### PR TITLE
Add Assert to not try to divide by zero

### DIFF
--- a/Sources/JTAppleCalendar/CalendarEnums.swift
+++ b/Sources/JTAppleCalendar/CalendarEnums.swift
@@ -72,7 +72,7 @@ public enum ScrollingMode: Equatable {
     case nonStopToSection(withResistance: CGFloat)
     /// nonStopToCell - continuous scrolling that will stop at a cell
     case nonStopToCell(withResistance: CGFloat)
-    /// nonStopTo - continuous scrolling that will stop at acustom interval
+    /// nonStopTo - continuous scrolling that will stop at acustom interval, do not use 0 as custom interval
     case nonStopTo(customInterval: CGFloat, withResistance: CGFloat)
     /// none - continuous scrolling that will eventually stop at a point
     case none

--- a/Sources/JTAppleCalendar/JTACMonthQueryFunctions.swift
+++ b/Sources/JTAppleCalendar/JTACMonthQueryFunctions.swift
@@ -63,6 +63,7 @@ extension JTACMonthView {
 
         switch scrollingMode {
         case .stopAtEachCalendarFrame, .stopAtEach, .nonStopTo:
+            assert(fixedScrollSize != 0, "You should not try to divide by zero.")
             let frameSection = theTargetContentOffset / fixedScrollSize
             let roundedFrameSection = floor(frameSection)
             if scrollDirection == .horizontal {


### PR DESCRIPTION
Me and my colleagues made the migration to version 8.0 this week and experienced a crash in our application. We were wondering what the issue could be. It took us a while to figure it out and that's the reason why I add this PR. 
I added an assert and updated the documentation a bit to hopefully help some others to not try to divide by zero. 

We had the following code in our application: 
`calendarView.scrollingMode = .nonStopTo(customInterval: 0, withResistance: 0)`
and it totally worked fine in JTAppleCalendar 7.1.7. 

We changed it to 
`calendarView.scrollingMode = .nonStopTo(customInterval: 1, withResistance: 0)`
in Version 8.0.2 and it now works like before. 