### PR TITLE
Add support for ScrollingMode.stopAtEachFirstRowOfSection

### DIFF
--- a/SampleJTAppleCalendar/Example Calendars/ViewController.swift
+++ b/SampleJTAppleCalendar/Example Calendars/ViewController.swift
@@ -40,7 +40,8 @@ class ViewController: UIViewController {
         .nonStopToSection(withResistance: 0.5),
         .stopAtEach(customInterval: 374),
         .stopAtEachCalendarFrame,
-        .stopAtEachSection
+        .stopAtEachSection,
+        .stopAtEachFirstRowOfSection
     ]
     
     @IBAction func changeScroll(_ sender: Any) {

--- a/Sources/JTAppleCalendar/CalendarEnums.swift
+++ b/Sources/JTAppleCalendar/CalendarEnums.swift
@@ -66,6 +66,8 @@ public enum ScrollingMode: Equatable {
     case stopAtEachCalendarFrame
     /// stopAtEachSection - non-continuous scrolling that will stop at each section
     case stopAtEachSection
+    /// stopAtEachFirstRowOfSection - non-continous scrolling that will stop at first row of each section
+    case stopAtEachFirstRowOfSection
     /// stopAtEach - non-continuous scrolling that will stop at each custom interval
     case stopAtEach(customInterval: CGFloat)
     /// nonStopToSection - continuous scrolling that will stop at a section

--- a/Sources/JTAppleCalendar/JTACMonthView.swift
+++ b/Sources/JTAppleCalendar/JTACMonthView.swift
@@ -198,7 +198,7 @@ open class JTACMonthView: UICollectionView {
     var decelerationRateMatchingScrollingMode: CGFloat {
         switch scrollingMode {
         case .stopAtEachCalendarFrame: return UIScrollView.DecelerationRate.fast.rawValue
-        case .stopAtEach, .stopAtEachSection: return UIScrollView.DecelerationRate.fast.rawValue
+        case .stopAtEach, .stopAtEachSection, .stopAtEachFirstRowOfSection: return UIScrollView.DecelerationRate.fast.rawValue
         case .nonStopToSection, .nonStopToCell, .nonStopTo, .none: return UIScrollView.DecelerationRate.normal.rawValue
         }
     }

--- a/Sources/JTAppleCalendar/JTACScrollViewDelegates.swift
+++ b/Sources/JTAppleCalendar/JTACScrollViewDelegates.swift
@@ -122,6 +122,49 @@ extension JTACMonthView: UIScrollViewDelegate {
                                     setTargetContentOffset(endOfCurrentSectionOffset)
                                 }
                            })
+        case .stopAtEachFirstRowOfSection:
+            let section = scrollDecision(currentScrollDirectionValue: translation,
+                                                     previousScrollDirectionValue: lastMovedScrollDirection,
+                                                     forward: { return theCurrentSection},
+                                                     backward: { return theCurrentSection - 1},
+                                                     fixed: { return theCurrentSection})
+
+            guard section >= 0, section < calendarLayout.endOfSectionOffsets.count else {setTargetContentOffset(0); return}
+            
+            func monthHeaderSize(for section: Int) -> CGFloat {
+                guard let monthOfYear = self.monthInfoFromSection(section)?.month,
+                    let month = MonthsOfYear(rawValue: monthOfYear) else { return 0 }
+                
+                return self.lastMonthSize[month] ?? self.lastMonthSize["default"] ?? 0
+            }
+            
+            let endOfCurrentSectionOffset = calendarLayout.endOfSectionOffsets[theCurrentSection] + monthHeaderSize(for: theCurrentSection)
+            let previousSection = theCurrentSection - 1 < 0 ? 0 : theCurrentSection - 1
+            let endOfPreviousSectionOffset = calendarLayout.endOfSectionOffsets[previousSection] + monthHeaderSize(for: previousSection)
+            let midPoint = (endOfCurrentSectionOffset + endOfPreviousSectionOffset) / 2
+            let maxSnap = calendarLayout.endOfSectionOffsets[section]
+            
+            let userPercentage: CGFloat = 20
+            let modifiedPercentage = CGFloat((100 - userPercentage) / 100.0)
+            
+            let snapForward = midPoint - ((maxSnap - midPoint) * modifiedPercentage)
+            
+            scrollDecision(currentScrollDirectionValue: translation,
+                           previousScrollDirectionValue: lastMovedScrollDirection,
+                           forward: {
+                                if theCurrentContentOffset >= snapForward || directionVelocity > 0 {
+                                    setTargetContentOffset(endOfCurrentSectionOffset)
+                                } else {
+                                    setTargetContentOffset(endOfPreviousSectionOffset)
+                                }
+                           },
+                           backward: {
+                                if theCurrentContentOffset <= snapForward || directionVelocity < 0 {
+                                    setTargetContentOffset(endOfPreviousSectionOffset)
+                                } else {
+                                    setTargetContentOffset(endOfCurrentSectionOffset)
+                                }
+                           })
         case let .nonStopToCell(withResistance: resistance), let .nonStopToSection(withResistance: resistance):
             
             let (recalculatedOffset, elementProperties) = rectAfterApplying(resistance: resistance,


### PR DESCRIPTION
- Added `ScrollingMode.stopAtEachFirstRowOfSection` support - it stops scrolling at each first row of section.
- Added to new ScrollingMode to _Example_ project