### PR TITLE
callback scrollDidEndDecelerating delegate at right time

### DIFF
--- a/Sources/JTAppleCalendar/JTACScrollViewDelegates.swift
+++ b/Sources/JTAppleCalendar/JTACScrollViewDelegates.swift
@@ -178,9 +178,13 @@ extension JTACMonthView: UIScrollViewDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
             self.decelerationRate = UIScrollView.DecelerationRate(rawValue: self.decelerationRateMatchingScrollingMode)
         }
-        
-        DispatchQueue.main.async {
-            self.calendarDelegate?.scrollDidEndDecelerating(for: self)
+    }
+    
+    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if decelerate {
+            DispatchQueue.main.async {
+                self.calendarDelegate?.scrollDidEndDecelerating(for: self)
+            }
         }
     }
     


### PR DESCRIPTION
for [issue#1260](https://github.com/patchthecode/JTAppleCalendar/issues/1260) 

scrollDidEndDecelerating should not be called when decelerate is false.