### PR TITLE
Updated the sample app's "ViewController.swift" file to update the "m…

### DIFF
--- a/SampleJTAppleCalendar/Example Calendars/ViewController.swift
+++ b/SampleJTAppleCalendar/Example Calendars/ViewController.swift
@@ -424,12 +424,11 @@ extension ViewController: JTACMonthViewDelegate, JTACMonthViewDataSource {
     }
     
     func calendar(_ calendar: JTACMonthView, didScrollToDateSegmentWith visibleDates: DateSegmentInfo) {
-//        print("After: \(calendar.contentOffset.y)")
-
+        setupViewsOfCalendar(from: visibleDates)
     }
     
     func calendar(_ calendar: JTACMonthView, willScrollToDateSegmentWith visibleDates: DateSegmentInfo) {
-        setupViewsOfCalendar(from: visibleDates)
+        //setupViewsOfCalendar(from: visibleDates)
     }
     
     func calendar(_ calendar: JTACMonthView, headerViewForDateRange range: (start: Date, end: Date), at indexPath: IndexPath) -> JTACMonthReusableView {


### PR DESCRIPTION
…onthLabel" when the user clicks "next" or "previous". It appears that "didScrollToDateSegmentWith" alone, and not "willScrollToDateSegmentWith" is called when we use JTACMonthView.scrollToSegment. So I moved the code that updates the monthLabel text within didScrollToDateSegmentWith instead of willScrollToDateSegmentWith.