### PR TITLE
Deprecation warning fix for misc protocols from `class` to `AnyObject`

### DIFF
--- a/Sources/JTAppleCalendar/JTACMonthCell.swift
+++ b/Sources/JTAppleCalendar/JTACMonthCell.swift
@@ -25,7 +25,7 @@
 import Foundation
 import UIKit
 
-public protocol JTACCellMonthViewDelegate: class {
+public protocol JTACCellMonthViewDelegate: AnyObject {
     func monthView(_ monthView: JTACCellMonthView,
                   drawingFor segmentRect: CGRect,
                   with date: Date,

--- a/Sources/JTAppleCalendar/JTACMonthDelegateProtocol.swift
+++ b/Sources/JTAppleCalendar/JTACMonthDelegateProtocol.swift
@@ -24,7 +24,7 @@
 import Foundation
 import UIKit
 
-protocol JTACMonthDelegateProtocol: class {
+protocol JTACMonthDelegateProtocol: AnyObject {
     // Variables
     var allowsDateCellStretching: Bool {get set}
     var _cachedConfiguration: ConfigurationParameters! {get set}

--- a/Sources/JTAppleCalendar/JTACMonthLayoutProtocol.swift
+++ b/Sources/JTAppleCalendar/JTACMonthLayoutProtocol.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-protocol JTACMonthLayoutProtocol: class {
+protocol JTACMonthLayoutProtocol: AnyObject {
     var minimumInteritemSpacing: CGFloat {get set}
     var minimumLineSpacing: CGFloat {get set}
     var sectionInset: UIEdgeInsets {get set}

--- a/Sources/JTAppleCalendar/JTACMonthViewProtocols.swift
+++ b/Sources/JTAppleCalendar/JTACMonthViewProtocols.swift
@@ -31,8 +31,8 @@ import UIKit
 /// the calendar-view object with the information it needs to construct and
 /// then modify it self
 @available(*, unavailable, renamed: "JTACMonthViewDataSource")
-public protocol JTAppleCalendarViewDataSource: class {}
-public protocol JTACMonthViewDataSource: class {
+public protocol JTAppleCalendarViewDataSource: AnyObject {}
+public protocol JTACMonthViewDataSource: AnyObject {
     /// Asks the data source to return the start and end boundary dates
     /// as well as the calendar to use. You should properly configure
     /// your calendar at this point.
@@ -47,8 +47,8 @@ public protocol JTACMonthViewDataSource: class {
 /// JTAppleCalendarMonthViewDelegate protocol Optional methods of the protocol
 /// allow the delegate to manage selections, and configure the cells
 @available(*, unavailable, renamed: "JTACMonthViewDelegate")
-public protocol JTAppleCalendarViewDelegate: class {}
-public protocol JTACMonthViewDelegate: class {
+public protocol JTAppleCalendarViewDelegate: AnyObject {}
+public protocol JTACMonthViewDelegate: AnyObject {
     /// Asks the delegate if selecting the date-cell with a specified date is
     /// allowed
     /// - Parameters:

--- a/Sources/JTAppleCalendar/JTACYearViewProtocols.swift
+++ b/Sources/JTAppleCalendar/JTACYearViewProtocols.swift
@@ -25,7 +25,7 @@
 import Foundation
 import UIKit
 
-public protocol JTACYearViewDelegate: class {
+public protocol JTACYearViewDelegate: AnyObject {
     func calendar(_ calendar: JTACYearView, cellFor item: Any, at date: Date, indexPath: IndexPath) -> JTACMonthCell
     func calendar(_ calendar: JTACYearView,
                   monthView: JTACCellMonthView,
@@ -46,7 +46,7 @@ extension JTACYearViewDelegate {
     func calendar(_ calendar: JTACYearView, sizeFor item: Any) -> CGSize { return .zero }
 }
 
-public protocol JTACYearViewDataSource: class {
+public protocol JTACYearViewDataSource: AnyObject {
     func configureCalendar(_ calendar: JTACYearView) -> (configurationParameters: ConfigurationParameters, months: [Any])
 }
 


### PR DESCRIPTION
I was updating my iOS app to be able to run on Xcode 12.5 (beta) and noticed that Apple is now flagging the use of `class` inherited protocols as `deprecated` in favor of inheriting from `AnyObject`. In my iOS app, we flag warnings as errors so now our app won't compile. I wanted to be able to pitch in and help modernize the code so I went ahead and fixed this deprecation here. 

<img width="853" alt="image" src="https://user-images.githubusercontent.com/1315688/107282661-248a5a80-6a10-11eb-806b-5be48827b35f.png">

After a little bit of research, I came across this forum Swift.org [post](https://forums.swift.org/t/class-only-protocols-class-vs-anyobject/11507/4) which seems to point to the discussion where this deprecation discussion started.