### PR TITLE
Crash when creating cell extending JTACMonthCell programatically #1158

### DIFF
--- a/Sources/JTAppleCalendar/JTACMonthCell.swift
+++ b/Sources/JTAppleCalendar/JTACMonthCell.swift
@@ -34,8 +34,8 @@ public protocol JTACCellMonthViewDelegate: AnyObject {
 }
 
 open class JTACMonthCell: UICollectionViewCell {
-    @IBOutlet var monthView: JTACCellMonthView?
-    weak var delegate: JTACCellMonthViewDelegate?
+    @IBOutlet open var monthView: JTACCellMonthView?
+    weak open var delegate: JTACCellMonthViewDelegate?
     
     func setupWith(configurationParameters: ConfigurationParameters,
                    month: Month,


### PR DESCRIPTION
Changed access modifier to open to allow subclasses to access and create the required view