### PR TITLE
Fix #1217 - converted some properties from implicitly unwrapped optionals to address crash

### DIFF
--- a/Sources/JTAppleCalendar/JTACInteractionMonthFunctions.swift
+++ b/Sources/JTAppleCalendar/JTACInteractionMonthFunctions.swift
@@ -433,7 +433,7 @@ extension JTACMonthView {
         
         switch scrollDirection {
         case .horizontal:
-            if calendarViewLayout.thereAreHeaders || _cachedConfiguration.generateOutDates == .tillEndOfGrid {
+            if calendarViewLayout.thereAreHeaders || _cachedConfiguration?.generateOutDates == .tillEndOfGrid {
                 fixedScrollSize = calendarViewLayout.sizeOfContentForSection(0)
             } else {
                 fixedScrollSize = frame.width

--- a/Sources/JTAppleCalendar/JTACMonthActionFunctions.swift
+++ b/Sources/JTAppleCalendar/JTACMonthActionFunctions.swift
@@ -249,12 +249,12 @@ extension JTACMonthView {
                 // ConfigParameters were changed
                 newStartOfMonth                     != oldStartOfMonth ||
                 newEndOfMonth                       != oldEndOfMonth ||
-                newDateBoundary.calendar            != _cachedConfiguration.calendar ||
-                newDateBoundary.numberOfRows        != _cachedConfiguration.numberOfRows ||
-                newDateBoundary.generateInDates     != _cachedConfiguration.generateInDates ||
-                newDateBoundary.generateOutDates    != _cachedConfiguration.generateOutDates ||
-                newDateBoundary.firstDayOfWeek      != _cachedConfiguration.firstDayOfWeek ||
-                newDateBoundary.hasStrictBoundaries != _cachedConfiguration.hasStrictBoundaries ||
+                newDateBoundary.calendar            != _cachedConfiguration?.calendar ||
+                newDateBoundary.numberOfRows        != _cachedConfiguration?.numberOfRows ||
+                newDateBoundary.generateInDates     != _cachedConfiguration?.generateInDates ||
+                newDateBoundary.generateOutDates    != _cachedConfiguration?.generateOutDates ||
+                newDateBoundary.firstDayOfWeek      != _cachedConfiguration?.firstDayOfWeek ||
+                newDateBoundary.hasStrictBoundaries != _cachedConfiguration?.hasStrictBoundaries ||
                 // Other layout information were changed
                 minimumInteritemSpacing  != calendarLayout.minimumInteritemSpacing ||
                 minimumLineSpacing       != calendarLayout.minimumLineSpacing ||

--- a/Sources/JTAppleCalendar/JTACMonthDelegateProtocol.swift
+++ b/Sources/JTAppleCalendar/JTACMonthDelegateProtocol.swift
@@ -27,7 +27,7 @@ import UIKit
 protocol JTACMonthDelegateProtocol: AnyObject {
     // Variables
     var allowsDateCellStretching: Bool {get set}
-    var _cachedConfiguration: ConfigurationParameters! {get set}
+    var _cachedConfiguration: ConfigurationParameters? {get set}
     var calendarDataSource: JTACMonthViewDataSource? {get set}
     var cellSize: CGFloat {get set}
     var anchorDate: Date? {get set}

--- a/Sources/JTAppleCalendar/JTACMonthLayoutHorizontalCalendar.swift
+++ b/Sources/JTAppleCalendar/JTACMonthLayoutHorizontalCalendar.swift
@@ -65,7 +65,7 @@ extension JTACMonthLayout {
                             xStride = contentWidth
                             endOfSectionOffsets.append(contentWidth)
                         } else {
-                            if totalDayCounter >= delegate.totalDays {
+                            if totalDayCounter >= delegate?.totalDays ?? 0 {
                                 contentWidth += (attribute.width * 7) + endSeparator
                                 endOfSectionOffsets.append(contentWidth)
                             }

--- a/Sources/JTAppleCalendar/JTACMonthLayoutVerticalCalendar.swift
+++ b/Sources/JTAppleCalendar/JTACMonthLayoutVerticalCalendar.swift
@@ -77,7 +77,7 @@ extension JTACMonthLayout {
                             endOfSectionOffsets.append(contentHeight - sectionInset.top)
                             
                         } else {
-                            if totalDayCounter >= delegate.totalDays {
+                            if totalDayCounter >= delegate?.totalDays ?? 0 {
                                 yCellOffset += attribute.height + sectionInset.top
                                 contentHeight = yCellOffset
                                 endOfSectionOffsets.append(contentHeight - sectionInset.top)

--- a/Sources/JTAppleCalendar/JTACMonthQueryFunctions.swift
+++ b/Sources/JTAppleCalendar/JTACMonthQueryFunctions.swift
@@ -135,9 +135,9 @@ extension JTACMonthView {
     }
     
     func indexPathOfdateCellCounterPath(_ date: Date, dateOwner: DateOwner) -> IndexPath? {
-        if (_cachedConfiguration.generateInDates == .off ||
-            _cachedConfiguration.generateInDates == .forFirstMonthOnly) &&
-            _cachedConfiguration.generateOutDates == .off {
+        if (_cachedConfiguration?.generateInDates == .off ||
+            _cachedConfiguration?.generateInDates == .forFirstMonthOnly) &&
+            _cachedConfiguration?.generateOutDates == .off {
             return nil
         }
         var retval: IndexPath?
@@ -377,7 +377,7 @@ extension JTACMonthView {
         }
         if let monthDate = calendar.date(byAdding: .month, value: monthIndex, to: startDateCache) {
             let monthNumber = calendar.dateComponents([.month], from: monthDate)
-            let numberOfRowsForSection = monthData.numberOfRows(for: section, developerSetRows: _cachedConfiguration.numberOfRows)
+            let numberOfRowsForSection = monthData.numberOfRows(for: section, developerSetRows: _cachedConfiguration?.numberOfRows ?? 0)
             return ((startDate, endDate), monthNumber.month!, numberOfRowsForSection)
         }
         return nil

--- a/Sources/JTAppleCalendar/JTACMonthView.swift
+++ b/Sources/JTAppleCalendar/JTACMonthView.swift
@@ -112,7 +112,7 @@ open class JTACMonthView: UICollectionView {
     }
     
     // Configuration parameters from the dataSource
-    var _cachedConfiguration: ConfigurationParameters!
+    var _cachedConfiguration: ConfigurationParameters?
     // Set the start of the month
     var startOfMonthCache: Date!
     // Set the end of month


### PR DESCRIPTION
This PR changes `JTACMonthLayout.delegate` and `JTACMonthDelegateProtocol._cachedConfiguration` from implicitly unwrapped options to optionals. It addresses a crash reported in #1217 where the following line crashes in rare circumstances due to a force unwrapped optional with a nil value.

JTACMonthLayout.Swift:168:
```
strictBoundaryRulesShouldApply = thereAreHeaders || delegate._cachedConfiguration.hasStrictBoundaries
```

Although I don't know under which circumstances the implicitly unwrapped optional(s) are `nil`, this PR will at least prevent the crash. It should have no impact on functionality.