### PR TITLE
MonthsOfYear and DaysOfWeek conforming to protocol CaseIterable

### DIFF
--- a/Sources/JTAppleCalendar/CalendarEnums.swift
+++ b/Sources/JTAppleCalendar/CalendarEnums.swift
@@ -108,7 +108,7 @@ public enum DateOwner: Int {
         followingMonthOutsideBoundary
 }
 /// Months of the year
-public enum MonthsOfYear: Int {
+public enum MonthsOfYear: Int, CaseIterable {
     case jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec
 }
 
@@ -131,7 +131,7 @@ public enum SelectionType: String {
 
 /// Days of the week. By setting your calendar's first day of the week,
 /// you can change which day is the first for the week. Sunday is the default value.
-public enum DaysOfWeek: Int {
+public enum DaysOfWeek: Int, CaseIterable {
     /// Days of the week.
     case sunday = 1, monday, tuesday, wednesday, thursday, friday, saturday
 }

--- a/Sources/JTAppleCalendar/CalendarStructs.swift
+++ b/Sources/JTAppleCalendar/CalendarStructs.swift
@@ -275,7 +275,7 @@ class JTAppleDateConfigGenerator {
             
             // Track the month name index
             var monthNameIndex = parameters.calendar.component(.month, from: parameters.startDate) - 1
-            let allMonthsOfYear: [MonthsOfYear] = [.jan, .feb, .mar, .apr, .may, .jun, .jul, .aug, .sep, .oct, .nov, .dec]
+            let allMonthsOfYear = MonthsOfYear.allCases
             
             for monthIndex in 0 ..< numberOfMonths {
                 if let currentMonthDate = parameters.calendar.date(byAdding: .month, value: monthIndex, to: parameters.startDate) {


### PR DESCRIPTION
This PR  is for the issue https://github.com/patchthecode/JTAppleCalendar/issues/1326.

Although not mentioned in this issue, I think there is a demand for `DaysOfWeek` to handle all cases as a collection as well, so  it also conforms to the `CaseIterable` protocol. (In fact, I want to treat all cases of `DaysOfWeek` as a collection  in my project.)

