### PR TITLE
Correct numerical errors in roundedFrameSection calculation

### DIFF
--- a/Sources/JTAppleCalendar/JTACMonthQueryFunctions.swift
+++ b/Sources/JTAppleCalendar/JTACMonthQueryFunctions.swift
@@ -65,7 +65,11 @@ extension JTACMonthView {
         case .stopAtEachCalendarFrame, .stopAtEach, .nonStopTo:
             assert(fixedScrollSize != 0, "You should not try to divide by zero.")
             let frameSection = theTargetContentOffset / fixedScrollSize
-            let roundedFrameSection = floor(frameSection)
+            // Reduce the precision of `frameSection` before calling `floor()` to eliminate numerical
+            // errors that would produce the wrong result. For example, if `frameSection == 49.9999999999999`,
+            // the double precision calculation will incorrectly procude 49 while the float precision
+            // calculation will correctly produce 50.
+            let roundedFrameSection = CGFloat(floor(Float(frameSection)))
             if scrollDirection == .horizontal {
                 x = roundedFrameSection * fixedScrollSize
             } else {


### PR DESCRIPTION
In my project, I have a calendar view that scrolls horizontaly one month at a time:

<img width="847" alt="image" src="https://user-images.githubusercontent.com/2529176/175841681-0e14e938-521d-4823-8b73-2fdaf1cdbcbb.png">

When calling `calendar.scrollToDate()`, the calendar was scrolling to the wrong month anytime the specified date was a Sunday. Specifically, it was scrolling to the next previous month.

The problem is due to the formula `floor(frameSection)` in `targetPointForItemAt()`. Naturally, `frameSection` may have small numerical errors. For example, a Sunday may yield `frameSection == 49.9999999999999`. However, `floor(49.9999999999999) == 49` when the correct calculation should be 50.

One potential fix, which is the one I'm submitting in this PR, is to reduce the numerical precision of `frameSection` from double to single before calling `floor()`. This correctly results in `floor(50) == 50`.