### PR TITLE
Fix Xcode 15 compilation

### DIFF
--- a/Sources/JTAppleCalendar/JTACMonthView.swift
+++ b/Sources/JTAppleCalendar/JTACMonthView.swift
@@ -63,8 +63,6 @@ open class JTACMonthView: UICollectionView {
     /// then whenever you click on a datecell, you may notice a very fast
     /// refreshing of the date-cells both left and right of the cell you
     /// just selected.
-    @available(*, unavailable, renamed: "allowsRangedSelection")
-    open var isRangeSelectionUsed: Bool = false
     open var allowsRangedSelection: Bool = false
   
     open var rangeSelectionMode: RangeSelectionMode = .segmented


### PR DESCRIPTION
Remove isRangeSelectionUsed declaration in order to make JTAppleCalendar compatible with Xcode 15.